### PR TITLE
Locking now considers the chronology of the jobs

### DIFF
--- a/service/archive/archiveRunner.go
+++ b/service/archive/archiveRunner.go
@@ -82,7 +82,7 @@ func (a *archiveRunner) watchState(archiveJob *batchv1.Job) {
 	watch := observe.WatchObjects{
 		Logger:  a.Logger,
 		Job:     archiveJob,
-		JobType: observe.RestoreType,
+		JobName: observe.RestoreName,
 		Locker:  a.observer.GetLocker(),
 		Successfunc: func(message observe.PodState) {
 			a.archiver.Status.Finished = true

--- a/service/backup/backupRunner.go
+++ b/service/backup/backupRunner.go
@@ -77,7 +77,7 @@ func (b *backupRunner) watchState(backupJob *batchv1.Job) {
 
 	watch := observe.WatchObjects{
 		Job:     backupJob,
-		JobType: observe.BackupType,
+		JobName: observe.BackupName,
 		Locker:  b.observer.GetLocker(),
 		Logger:  b.Logger,
 		Failedfunc: func(message observe.PodState) {

--- a/service/check/checkRunner.go
+++ b/service/check/checkRunner.go
@@ -79,7 +79,7 @@ func (c *checkRunner) watchState(job *batchv1.Job) {
 
 	watch := observe.WatchObjects{
 		Job:     job,
-		JobType: observe.CheckType,
+		JobName: observe.CheckName,
 		Locker:  c.observer.GetLocker(),
 		Logger:  c.Logger,
 		Failedfunc: func(message observe.PodState) {

--- a/service/observe/locker_test.go
+++ b/service/observe/locker_test.go
@@ -6,14 +6,20 @@ import (
 	"time"
 )
 
+// The waitForRun tests take quite some time due to the sleeps. Use at least
+// 60 seconds timeout here.
+
 func Test_concreteLocker_WaitForRun(t *testing.T) {
 	type fields struct {
 		semaphores semaphoreMap
 		mutex      sync.Mutex
 	}
 	type args struct {
-		backend string
-		jobs    []JobType
+		backend            string
+		jobs               []JobName
+		register           []JobName
+		unlock             map[int]JobType
+		jobIndexForWaiting int
 	}
 	tests := []struct {
 		name          string
@@ -24,32 +30,103 @@ func Test_concreteLocker_WaitForRun(t *testing.T) {
 	}{
 		{
 			name:        "Block for 1 second",
-			unlockAfter: 1,
+			unlockAfter: 2,
 			fields: fields{
-				semaphores: &concreteSemaphoreMap{},
-				mutex:      sync.Mutex{},
+				semaphores: &concreteSemaphoreMap{
+					mutexMap: make(map[string]semaphore),
+				},
+				mutex: sync.Mutex{},
 			},
 			args: args{
-				backend: "test",
-				jobs:    []JobType{BackupType},
+				backend:  "test",
+				jobs:     []JobName{BackupName},
+				register: []JobName{BackupName},
+				unlock: map[int]JobType{
+					0: JobType{},
+				},
+				jobIndexForWaiting: 0,
 			},
 		},
 		{
 			name:        "Block all jobs",
 			unlockAfter: 5,
 			fields: fields{
-				semaphores: &concreteSemaphoreMap{},
-				mutex:      sync.Mutex{},
+				semaphores: &concreteSemaphoreMap{
+					mutexMap: make(map[string]semaphore),
+				},
+				mutex: sync.Mutex{},
 			},
 			args: args{
 				backend: "test",
-				jobs: []JobType{
-					BackupType,
-					CheckType,
-					RestoreType,
-					PruneType,
+				jobs: []JobName{
+					BackupName,
+					CheckName,
+					RestoreName,
+					PruneName,
 				},
+				register: []JobName{
+					BackupName,
+					CheckName,
+					RestoreName,
+					PruneName,
+				},
+				unlock: map[int]JobType{
+					0: JobType{},
+					1: JobType{},
+					2: JobType{},
+					3: JobType{},
+				},
+				jobIndexForWaiting: 3,
 			},
+		},
+		{
+			name:        "Register backup during prune",
+			unlockAfter: 5,
+			fields: fields{
+				semaphores: &concreteSemaphoreMap{
+					mutexMap: make(map[string]semaphore),
+				},
+				mutex: sync.Mutex{},
+			},
+			args: args{
+				backend: "test",
+				jobs: []JobName{
+					BackupName,
+				},
+				register: []JobName{
+					BackupName,
+					PruneName,
+					BackupName,
+				},
+				unlock: map[int]JobType{
+					0: JobType{},
+				},
+				jobIndexForWaiting: 1,
+			},
+		},
+		{
+			name:        "Lock forever",
+			unlockAfter: 1,
+			fields: fields{
+				semaphores: &concreteSemaphoreMap{
+					mutexMap: make(map[string]semaphore),
+				},
+				mutex: sync.Mutex{},
+			},
+			args: args{
+				backend: "test",
+				jobs: []JobName{
+					BackupName,
+				},
+				register: []JobName{
+					BackupName,
+					PruneName,
+					BackupName,
+				},
+				unlock:             map[int]JobType{},
+				jobIndexForWaiting: 1,
+			},
+			allowedToFail: true,
 		},
 	}
 	for _, tt := range tests {
@@ -59,30 +136,41 @@ func Test_concreteLocker_WaitForRun(t *testing.T) {
 				mutex:      tt.fields.mutex,
 			}
 
-			for _, job := range tt.args.jobs {
-				c.Increment(tt.args.backend, job)
+			var jobToWaitfor JobType
+
+			for i, job := range tt.args.register {
+				newJob := c.Increment(tt.args.backend, job)
+				if len(tt.args.unlock) >= i && !tt.allowedToFail {
+					tt.args.unlock[i] = newJob
+				}
+				if i == tt.args.jobIndexForWaiting {
+					jobToWaitfor = newJob
+				}
 			}
 
 			finished := make(chan bool, 0)
 
 			go func() {
-				c.WaitForRun(tt.args.backend, tt.args.jobs)
+				c.WaitForRun(jobToWaitfor.Backend, tt.args.jobs)
 				finished <- true
 			}()
 
 			go func() {
-				time.Sleep(time.Second * time.Duration(tt.unlockAfter))
-				for _, job := range tt.args.jobs {
-					c.Decrement(tt.args.backend, job)
+				for i := 0; i < len(tt.args.unlock); i++ {
+					time.Sleep(time.Second * time.Duration(tt.unlockAfter))
+					c.Decrement(tt.args.unlock[i])
 				}
 			}()
 
 			select {
-			case <-time.After(25 * time.Second):
+			case <-time.After(time.Duration(tt.unlockAfter*2*len(tt.args.unlock)) * time.Second):
 				if !tt.allowedToFail {
 					t.Fail()
 				}
 			case <-finished:
+				if tt.allowedToFail {
+					t.Fail()
+				}
 				c.Remove(tt.args.backend)
 			}
 		})

--- a/service/observe/subscription.go
+++ b/service/observe/subscription.go
@@ -45,7 +45,8 @@ type WatchObjects struct {
 	Logger      log.Logger
 	Job         *batchv1.Job
 	Locker      Locker
-	JobType     JobType
+	jobType     JobType
+	JobName     JobName
 	Successfunc func(message PodState)
 	Failedfunc  func(message PodState)
 	Runningfunc func(message PodState)
@@ -157,20 +158,20 @@ func (s *Subscriber) WatchLoop(watch WatchObjects) {
 			if watch.Failedfunc != nil {
 				watch.Failedfunc(message)
 			}
-			watch.Locker.Decrement(backendString, watch.JobType)
+			watch.Locker.Decrement(watch.jobType)
 			return
 		case batchv1.JobComplete:
 			watch.Logger.Infof("%v finished successfully", jobString)
 			if watch.Successfunc != nil {
 				watch.Successfunc(message)
 			}
-			watch.Locker.Decrement(backendString, watch.JobType)
+			watch.Locker.Decrement(watch.jobType)
 			return
 		default:
 			watch.Logger.Infof("%v is %v", jobString, jobRunning)
 			if !running {
 				running = true
-				watch.Locker.Increment(backendString, watch.JobType)
+				watch.jobType = watch.Locker.Increment(backendString, watch.JobName)
 			}
 		}
 	}

--- a/service/observe/subscription_test.go
+++ b/service/observe/subscription_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	corev1 "k8s.io/api/core/v1"
+	batchv1 "k8s.io/api/batch/v1"
 )
 
 func TestBroker_Subscribe(t *testing.T) {
@@ -172,7 +172,7 @@ func TestBroker_Notify(t *testing.T) {
 				state: PodState{
 					BaasID:     "test",
 					Repository: "test",
-					State:      string(corev1.PodFailed),
+					State:      batchv1.JobFailed,
 				},
 			},
 		},
@@ -187,7 +187,7 @@ func TestBroker_Notify(t *testing.T) {
 				state: PodState{
 					BaasID:     "test",
 					Repository: "test",
-					State:      string(corev1.PodFailed),
+					State:      batchv1.JobFailed,
 				},
 			},
 		},

--- a/service/prune/pruneRunner.go
+++ b/service/prune/pruneRunner.go
@@ -155,7 +155,7 @@ func (p *pruneRunner) watchState(job *batchv1.Job) {
 
 	watch := observe.WatchObjects{
 		Job:     job,
-		JobType: observe.PruneType,
+		JobName: observe.PruneName,
 		Locker:  p.observer.GetLocker(),
 		Logger:  p.Logger,
 		Failedfunc: func(message observe.PodState) {


### PR DESCRIPTION
If there are multiple jobs queued up the locker will now check when what
job was inserted into the queue. This fixes following issue:

Before when a backup took to long and a prune was scheduled, the prune
would start to run as soon as the backup was finished. But if another
backup got queued up before that there was a deadlock.

That deadlock was caused by the semaphores that didn't follow the
ordering of the jobs. So the queud up and already locked prune job would
wait for all backups to finish before running. But the backup that was
queued up after is waiting for that prune to finish. Both jobs waited
for each other to finish -> classic deadlock.