### PR TITLE
Fix PVC backup restores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Simplyfied merging logic for backend configs using mergo
 ### Added
 - More monitoring metrics
+### Fixed
+- PVC restores now work correctly
 
 ## [v0.1.5]
 ### Fixed

--- a/service/restore/utils.go
+++ b/service/restore/utils.go
@@ -54,6 +54,9 @@ func newRestoreJob(restore *backupv1alpha1.Restore, config config) *batchv1.Job 
 
 	restoreJob.Spec.Template.Spec.Containers[0].Args = args
 
+	restoreJob.Spec.Template.Spec.Volumes = volumes
+	restoreJob.Spec.Template.Spec.Containers[0].VolumeMounts = mounts
+
 	restoreJob.Spec.Template.Spec.Containers[0].Env = setUpEnvVariables(restore, config)
 
 	return restoreJob
@@ -64,6 +67,13 @@ func setUpEnvVariables(restore *backupv1alpha1.Restore, config config) []corev1.
 
 	if restore.Spec.RestoreMethod.S3 != nil {
 		vars = append(vars, restore.Spec.RestoreMethod.S3.RestoreEnvs(config.Global)...)
+	}
+
+	if restore.Spec.RestoreMethod.Folder != nil {
+		vars = append(vars, corev1.EnvVar{
+			Name:  "RESTORE_DIR",
+			Value: service.RestorePath,
+		})
 	}
 
 	return vars


### PR DESCRIPTION
This commit contains fixes for the PVC restores. Previously there was some configuration missing for the restore pod to actually mount the PVC correctly. This commit fixes that issue.