### PR TITLE
Relaxing the image pull policy

### DIFF
--- a/service/common.go
+++ b/service/common.go
@@ -89,6 +89,12 @@ func GetBasicJob(kind string, config config.Global, object metav1.Object) *batch
 		config.Label:      "true",
 		config.Identifier: PseudoUUID(),
 	}
+	
+	pullPolicy := corev1.PullIfNotPresent
+	if strings.HasSuffix(config.Image, ":latest") {
+		pullPolicy = corev1.PullAlways
+	}
+	
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nameJob,
@@ -118,7 +124,7 @@ func GetBasicJob(kind string, config config.Global, object metav1.Object) *batch
 									Value: object.GetNamespace(),
 								},
 							},
-							ImagePullPolicy: corev1.PullAlways,
+							ImagePullPolicy: pullPolicy,
 							TTY:             true,
 							Stdin:           true,
 						},


### PR DESCRIPTION
One of our k8s clusters overloaded when too many backup jobs pulled `docker.io/vshn/wrestic:v0.0.10` for every job.

I was not able to test the modified operator yet. However, it compiles and I (coming from rust) believe this is a good sign.

Cheers,
Stefan