### PR TITLE
Rename annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Change defaults for `BACKUP_ANNOTATION` and `BACKUP_BACKUPCOMMANDANNOTATION`
+  to use `k8up.syn.tools` as their prefix.
 
 ## [v0.1.7] 2020-01-03
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+The annotations for including/excluding PVCs as well as the backupcommand annotation have changed. If you're using them this is a breaking change and needs to be adjusted properly.
+
 ### Changed
 - Change defaults for `BACKUP_ANNOTATION` and `BACKUP_BACKUPCOMMANDANNOTATION`
   to use `k8up.syn.tools` as their prefix.

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ web_dir := ./_public
 docker_cmd  ?= docker
 docker_opts ?= --rm --tty --user "$$(id -u)"
 
-antora_cmd  ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}":/antora vshn/antora:1.2
+antora_cmd  ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}":/antora vshn/antora:1.3
 antora_opts ?= --cache-dir=.cache/antora
 
 vale_cmd ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}"/docs/modules/ROOT/pages:/pages vshn/vale:1.1 --minAlertLevel=error /pages

--- a/docs/modules/ROOT/assets/attachments/slides_embedded.html
+++ b/docs/modules/ROOT/assets/attachments/slides_embedded.html
@@ -216,7 +216,7 @@ document.getElementsByTagName( 'head' )[0].appendChild( link );</script><!--[if 
     <span class="tok-l tok-l-Scalar tok-l-Scalar-Plain">labels</span><span class="tok-p tok-p-Indicator">:</span>
       <span class="tok-l tok-l-Scalar tok-l-Scalar-Plain">app</span><span class="tok-p tok-p-Indicator">:</span> <span class="tok-l tok-l-Scalar tok-l-Scalar-Plain">mariadb</span>
     <span class="tok-l tok-l-Scalar tok-l-Scalar-Plain">annotations</span><span class="tok-p tok-p-Indicator">:</span>
-      <span class="tok-l tok-l-Scalar tok-l-Scalar-Plain">appuio.ch/backupcommand</span><span class="tok-p tok-p-Indicator">:</span> <span class="tok-l tok-l-Scalar tok-l-Scalar-Plain">mysqldump -uroot -psecure --all-databases</span>
+      <span class="tok-l tok-l-Scalar tok-l-Scalar-Plain">k8up.syn.tools/backupcommand</span><span class="tok-p tok-p-Indicator">:</span> <span class="tok-l tok-l-Scalar tok-l-Scalar-Plain">mysqldump -uroot -psecure --all-databases</span>
 <span class="tok-l tok-l-Scalar tok-l-Scalar-Plain">&lt;SNIP&gt;</span>
 <span class="tok-nn">---</span></code></pre>
 <aside class="notes"><div class="paragraph"><p>With this annotation the operator will trigger that command inside the the container and capture the stdout to a backup.</p></div>

--- a/docs/modules/ROOT/pages/advanced-config.adoc
+++ b/docs/modules/ROOT/pages/advanced-config.adoc
@@ -8,7 +8,7 @@ The operator has two ways for configuration:
 == Environment variables
 
 * `BACKUP_IMAGE` URL of the restic image, default: `172.30.1.1:5000/myproject/restic`
-* `BACKUP_ANNOTATION` the annotation to be used for filtering, default: `appuio.ch/backup`
+* `BACKUP_ANNOTATION` the annotation to be used for filtering, default: `k8up.syn.tools/backup`
 * `BACKUP_CHECKSCHEDULE` the default check schedule, default: `0 0 * * 0`
 * `BACKUP_PODFILTER` the filter used to find the backup pods, default: `backupPod=true`
 * `BACKUP_DATAPATH` where the PVCs should get mounted in the container, default `/data`
@@ -17,7 +17,7 @@ The operator has two ways for configuration:
 * `BACKUP_RESTARTPOLICY` set the RestartPolicy for the backup jobs. According to the https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/[docs] this should be `OnFailure` for jobs that terminate, default: `OnFailure`
 * `BACKUP_METRICBIND` set the bind address for the prometheus endpoint, default: `:8080`
 * `BACKUP_PROMURL` set the operator wide default prometheus push gateway, default `http://127.0.0.1/`
-* `BACKUP_BACKUPCOMMANDANNOTATION` set the annotation name where the backup commands are stored, default `appuio.ch/backupcommand`
+* `BACKUP_BACKUPCOMMANDANNOTATION` set the annotation name where the backup commands are stored, default `k8up.syn.tools/backupcommand`
 * `BACKUP_PODEXECROLENAME` set the rolename that should be used for pod command execution, default `pod-executor`
 * `BACKUP_PODEXECACCOUNTNAME` set the service account name that should be used for the pod command execution, default: `pod-executor`
 * `BACKUP_GLOBALACCESSKEYID` set the S3 access key id to be used globaly
@@ -87,7 +87,7 @@ You can also add it to any pods that are running in the namespace:
 [source]
 --
 via kubectl:
-kubectl -n ${YOUR_NAMESPACE} annotate pods ${YOUR_POD_NAME} "appuio.ch/backupcommand=/bin/bash -c 'mysqldump -uroot -p\"\${MARIADB_ROOT_PASSWORD}\" --all-databases'" --overwrite
+kubectl -n ${YOUR_NAMESPACE} annotate pods ${YOUR_POD_NAME} "k8up.syn.tools/backupcommand=/bin/bash -c 'mysqldump -uroot -p\"\${MARIADB_ROOT_PASSWORD}\" --all-databases'" --overwrite
 
 in the manifest:
 spec:
@@ -98,7 +98,7 @@ spec:
       labels:
         app: mariadb
       annotations:
-        appuio.ch/backupcommand: /bin/bash -c 'mysqldump -uroot -p "${MARIADB_ROOT_PASSWORD}" --all-databases'
+        k8up.syn.tools/backupcommand: /bin/bash -c 'mysqldump -uroot -p "${MARIADB_ROOT_PASSWORD}" --all-databases'
 --
 ====
 

--- a/docs/modules/ROOT/pages/advanced-config.adoc
+++ b/docs/modules/ROOT/pages/advanced-config.adoc
@@ -7,30 +7,30 @@ The operator has two ways for configuration:
 
 == Environment variables
 
-* `BACKUP_IMAGE` URL of the restic image, default: `172.30.1.1:5000/myproject/restic`
 * `BACKUP_ANNOTATION` the annotation to be used for filtering, default: `k8up.syn.tools/backup`
-* `BACKUP_CHECKSCHEDULE` the default check schedule, default: `0 0 * * 0`
-* `BACKUP_PODFILTER` the filter used to find the backup pods, default: `backupPod=true`
-* `BACKUP_DATAPATH` where the PVCs should get mounted in the container, default `/data`
-* `BACKUP_JOBNAME` names for the backup job objects in OpenShift, default: `backupjob`
-* `BACKUP_PODNAME` names for the backup pod objects in OpenShift, default: `backupjob-pod`
-* `BACKUP_RESTARTPOLICY` set the RestartPolicy for the backup jobs. According to the https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/[docs] this should be `OnFailure` for jobs that terminate, default: `OnFailure`
-* `BACKUP_METRICBIND` set the bind address for the prometheus endpoint, default: `:8080`
-* `BACKUP_PROMURL` set the operator wide default prometheus push gateway, default `http://127.0.0.1/`
 * `BACKUP_BACKUPCOMMANDANNOTATION` set the annotation name where the backup commands are stored, default `k8up.syn.tools/backupcommand`
-* `BACKUP_PODEXECROLENAME` set the rolename that should be used for pod command execution, default `pod-executor`
-* `BACKUP_PODEXECACCOUNTNAME` set the service account name that should be used for the pod command execution, default: `pod-executor`
+* `BACKUP_CHECKSCHEDULE` the default check schedule, default: `0 0 * * 0`
+* `BACKUP_DATAPATH` where the PVCs should get mounted in the container, default `/data`
 * `BACKUP_GLOBALACCESSKEYID` set the S3 access key id to be used globaly
-* `BACKUP_GLOBALSECRETACCESSKEY` set the S3 secret access key to be used globaly
-* `BACKUP_GLOBALREPOPASSWORD` set the restic repository password to be used globaly
 * `BACKUP_GLOBALKEEPJOBS` set the count of jobs to keep globally
-* `BACKUP_GLOBALS3ENDPOINT` set the S3 endpoint to be used globally
-* `BACKUP_GLOBALS3BUCKET` set the S3 bucket to be used globally
-* `BACKUP_GLOBALSTATSURL` set the URL of wrestic to post additional metrics gloablly, default `""`
+* `BACKUP_GLOBALREPOPASSWORD` set the restic repository password to be used globaly
+* `BACKUP_GLOBALRESTORES3ACCESKEYID` set the global resotre S3 accessKeyID for restores
 * `BACKUP_GLOBALRESTORES3BUCKET` set the global restore S3 bucket for restores
 * `BACKUP_GLOBALRESTORES3ENDPOINT` set the global restore S3 endpoint for the restores (needs the scheme [http/https]
-* `BACKUP_GLOBALRESTORES3ACCESKEYID` set the global resotre S3 accessKeyID for restores
 * `BACKUP_GLOBALRESTORES3SECRETACCESSKEY` set the global restore S3 SecretAccessKey for restores
+* `BACKUP_GLOBALS3BUCKET` set the S3 bucket to be used globally
+* `BACKUP_GLOBALS3ENDPOINT` set the S3 endpoint to be used globally
+* `BACKUP_GLOBALSECRETACCESSKEY` set the S3 secret access key to be used globaly
+* `BACKUP_GLOBALSTATSURL` set the URL of wrestic to post additional metrics gloablly, default `""`
+* `BACKUP_IMAGE` URL of the restic image, default: `172.30.1.1:5000/myproject/restic`
+* `BACKUP_JOBNAME` names for the backup job objects in OpenShift, default: `backupjob`
+* `BACKUP_METRICBIND` set the bind address for the prometheus endpoint, default: `:8080`
+* `BACKUP_PODEXECACCOUNTNAME` set the service account name that should be used for the pod command execution, default: `pod-executor`
+* `BACKUP_PODEXECROLENAME` set the rolename that should be used for pod command execution, default `pod-executor`
+* `BACKUP_PODFILTER` the filter used to find the backup pods, default: `backupPod=true`
+* `BACKUP_PODNAME` names for the backup pod objects in OpenShift, default: `backupjob-pod`
+* `BACKUP_PROMURL` set the operator wide default prometheus push gateway, default `http://127.0.0.1/`
+* `BACKUP_RESTARTPOLICY` set the RestartPolicy for the backup jobs. According to the https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/[docs] this should be `OnFailure` for jobs that terminate, default: `OnFailure`
 
 You only need to adjust `BACKUP_IMAGE` everything else can be left default.
 

--- a/docs/modules/ROOT/pages/advanced-config.adoc
+++ b/docs/modules/ROOT/pages/advanced-config.adoc
@@ -11,6 +11,7 @@ The operator has two ways for configuration:
 * `BACKUP_BACKUPCOMMANDANNOTATION` set the annotation name where the backup commands are stored, default `k8up.syn.tools/backupcommand`
 * `BACKUP_CHECKSCHEDULE` the default check schedule, default: `0 0 * * 0`
 * `BACKUP_DATAPATH` where the PVCs should get mounted in the container, default `/data`
+* `BACKUP_FILEEXTENSIONANNOTATION` set the annotation name where the file extension is stored for backupcommands, default `k8up.syn.tools/file-extension`
 * `BACKUP_GLOBALACCESSKEYID` set the S3 access key id to be used globaly
 * `BACKUP_GLOBALKEEPJOBS` set the count of jobs to keep globally
 * `BACKUP_GLOBALREPOPASSWORD` set the restic repository password to be used globaly

--- a/docs/modules/ROOT/pages/getting-started.adoc
+++ b/docs/modules/ROOT/pages/getting-started.adoc
@@ -93,7 +93,7 @@ image::minio_browser.png[]
 
 Feel free to adjust the frequencies to your liking. To help you with the crontab syntax, we recommend to check https://crontab.guru[crontab.guru].
 
-TIP: You can always check the state and configuration of your backup by using `kubectl describe schedule` * By default all PVCs are stored in backup. By adding the annotation `appuio.ch/backup=false` to a PVC object it will get excluded from backup.
+TIP: You can always check the state and configuration of your backup by using `kubectl describe schedule` * By default all PVCs are stored in backup. By adding the annotation `k8up.syn.tools/backup=false` to a PVC object it will get excluded from backup.
 
 == Summary
 
@@ -123,7 +123,7 @@ template:
     labels:
       app: mariadb
     annotations:
-      appuio.ch/backupcommand: mysqldump -uroot -psecure --all-databases
+      k8up.syn.tools/backupcommand: mysqldump -uroot -psecure --all-databases
 <SNIP>
 ----
 

--- a/docs/modules/ROOT/pages/restore.adoc
+++ b/docs/modules/ROOT/pages/restore.adoc
@@ -54,7 +54,7 @@ metadata:
   #namespace: snapshot-test
   annotations:
     # set to "true" to include in future backups
-    appuio.ch/backup: "false"
+    k8up.syn.tools/backup: "false"
   # Optional:
   #labels:
   #  app: multi-file-writer

--- a/manifest/examples/deployments/mariadb.yaml
+++ b/manifest/examples/deployments/mariadb.yaml
@@ -26,7 +26,7 @@ spec:
       labels:
         app: mariadb
       annotations:
-        appuio.ch/backupcommand: mysqldump -uroot -psecure --all-databases
+        k8up.syn.tools/backupcommand: mysqldump -uroot -psecure --all-databases
     spec:
       containers:
         - env:

--- a/manifest/examples/deployments/mongodb.yaml
+++ b/manifest/examples/deployments/mongodb.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: '2018-07-31T11:10:46Z'
   generation: 4
   annotations:
-    appuio.ch/backupcommand: mongodump --archive -uroot -pexample
+    k8up.syn.tools/backupcommand: mongodump --archive -uroot -pexample
   labels:
     app: mongodb
   name: mongodb

--- a/manifest/examples/statefulset/10-galera.yaml
+++ b/manifest/examples/statefulset/10-galera.yaml
@@ -27,7 +27,7 @@ spec:
         app: mysql
       annotations:
         pod.alpha.kubernetes.io/initialized: "true"
-        appuio.ch/backupcommand: mysqldump -uroot -psecure --all-databases
+        k8up.syn.tools/backupcommand: mysqldump -uroot -psecure --all-databases
     spec:
       securityContext:
         runAsUser: 27

--- a/manifest/examples/storage/pvc-example.yaml
+++ b/manifest/examples/storage/pvc-example.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
   name: myclaim
   annotations:
-    appuio.ch/backup: 'true'
+    k8up.syn.tools/backup: 'true'
   namespace: myproject
 spec:
   accessModes:

--- a/service/backup/config.go
+++ b/service/backup/config.go
@@ -1,8 +1,8 @@
 package backup
 
 import (
-	configPackage "github.com/vshn/k8up/config"
 	"github.com/spf13/viper"
+	configPackage "github.com/vshn/k8up/config"
 )
 
 type config struct {
@@ -38,9 +38,9 @@ func newConfig() config {
 }
 
 func setDefaults() {
-	viper.SetDefault("annotation", "appuio.ch/backup")
+	viper.SetDefault("annotation", "k8up.syn.tools/backup")
 	viper.SetDefault("checkSchedule", "0 0 * * 0")
-	viper.SetDefault("backupCommandAnnotation", "appuio.ch/backupcommand")
+	viper.SetDefault("backupCommandAnnotation", "k8up.syn.tools/backupcommand")
 	viper.SetDefault("dataPath", "/data")
 	viper.SetDefault("jobName", "backupjob")
 	viper.SetDefault("podName", "backupjob-pod")

--- a/service/backup/config.go
+++ b/service/backup/config.go
@@ -46,5 +46,5 @@ func setDefaults() {
 	viper.SetDefault("podName", "backupjob-pod")
 	viper.SetDefault("PodExecRoleName", "pod-executor")
 	viper.SetDefault("PodExecAccountName", "pod-executor")
-	viper.SetDefault("FileExtensionAnnotation", "backup.appuio.ch/file-extension")
+	viper.SetDefault("FileExtensionAnnotation", "k8up.syn.tools/file-extension")
 }


### PR DESCRIPTION
This change renames the annotations. The will now use `k8up.syn.tools/…` as their prefix instead of `appuio.ch/…`.