### PR TITLE
Subscriber mutex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The annotations for including/excluding PVCs as well as the backupcommand annota
 ### Changed
 - Change defaults for `BACKUP_ANNOTATION` and `BACKUP_BACKUPCOMMANDANNOTATION`
   to use `k8up.syn.tools` as their prefix.
+### Fixed
+- Race conditions in the locking logic
 
 ## [v0.1.7] 2020-01-03
 ### Fixed


### PR DESCRIPTION
There's currently a race condition in the observer and locking mechanism of the operator. That race condition causes the operator the panic and restart. During that time it can happen that the operator misses a schedule. This is a hotfix to add mutexes to the logic. 

As the use case for the locking proved to not viable due to other reasons, we planned to remove the logic completely from the operator and move it to wrestic. This will greatly decrease the operators complexity as well as make the locking more reliable.