### PR TITLE
Fix/pass annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- The operator passes the cofnigured annotation names to Wrestic
 
 ## [v0.1.8] 2020-03-03
 The annotations for including/excluding PVCs as well as the backupcommand annotation have changed. If you're using them this is a breaking change and needs to be adjusted properly.

--- a/service/backup/utils.go
+++ b/service/backup/utils.go
@@ -67,6 +67,14 @@ func setUpEnvVariables(backup *backupv1alpha1.Backup, config config) []corev1.En
 			Name:  service.StatsURL,
 			Value: statsURL,
 		},
+		{
+			Name:  "BACKUPCOMMAND_ANNOTATION",
+			Value: config.backupCommandAnnotation,
+		},
+		{
+			Name:  "FILEEXTENSION_ANNOTATION",
+			Value: config.fileExtensionAnnotation,
+		},
 	}...)
 	return vars
 }

--- a/service/common.go
+++ b/service/common.go
@@ -159,7 +159,6 @@ func DefaultEnvs(backend *backupv1alpha1.Backend, config config.Global) []corev1
 }
 
 // BuildTagArgs will prepend "--tag " to every element in the given []string
-// TODO: this is wrong, needs fixing!!
 func BuildTagArgs(tagList []string) []string {
 	var args []string
 	for i := range tagList {


### PR DESCRIPTION
This enables the operator to pass the configured annotations for backup commands and feileextension to wrestic.

Thus fixing annotation missmatch between backup command templates and wrestic.