### PR TITLE
Rename baas -> k8up in manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ oc login -u system:admin # default developer account doesn't have the rights to 
 #The operator has the be run at least once before to create the CRD
 go run cmd/operator/*.go -development
 #Add a demo backupworker (adjust the variables to your liking first)
-kubectl apply -f manifest-examples/baas.yaml
+kubectl apply -f manifest-examples/k8up.yaml
 #Add a demo PVC if necessary
 kubectl apply -f manifest-examples/pvc.yaml
 ```
@@ -54,13 +54,13 @@ The container has to exist on the registry in order for the operator to find the
 ```
 minishift start
 oc login -u developer
-docker build -t $(minishift openshift registry)/myproject/baas:0.0.1 .
-docker save $(minishift openshift registry)/myproject/baas:0.0.1 > tmp.tar
+docker build -t $(minishift openshift registry)/myproject/k8up:0.0.1 .
+docker save $(minishift openshift registry)/myproject/k8up:0.0.1 > tmp.tar
 eval $(minishift docker-env)
 docker load -i tmp.tar
 rm tmp.tar
 docker login -u developer -p $(oc whoami -t) $(minishift openshift registry)
-docker push $(minishift openshift registry)/myproject/baas:0.0.1
+docker push $(minishift openshift registry)/myproject/k8up:0.0.1
 ```
 
 # Docker tags

--- a/manifest/examples/archive/archive.yaml
+++ b/manifest/examples/archive/archive.yaml
@@ -20,11 +20,10 @@ spec:
   backend:
     s3:
       endpoint: http://10.144.1.224:9000
-      bucket: baas
+      bucket: k8up
       accessKeyIDSecretRef:
         name: backup-credentials
         key: username
       secretAccessKeySecretRef:
         name: backup-credentials
         key: password
-

--- a/manifest/examples/backup/backup.yaml
+++ b/manifest/examples/backup/backup.yaml
@@ -1,13 +1,13 @@
 apiVersion: backup.appuio.ch/v1alpha1
 kind: Backup
 metadata:
-  name: baas-test
+  name: k8up-test
 spec:
   keepJobs: 4
   backend:
     s3:
       endpoint: http://10.144.1.224:9000
-      bucket: baas
+      bucket: k8up
       accessKeyIDSecretRef:
         name: backup-credentials
         key: username

--- a/manifest/examples/backup/schedule.yaml
+++ b/manifest/examples/backup/schedule.yaml
@@ -10,7 +10,7 @@ spec:
     backend:
       s3:
         endpoint: http://10.144.1.224:9000
-        bucket: baas
+        bucket: k8up
         accessKeyIDSecretRef:
           name: backup-credentials
           key: username

--- a/manifest/examples/check/check.yaml
+++ b/manifest/examples/check/check.yaml
@@ -6,7 +6,7 @@ spec:
   backend:
     s3:
       endpoint: http://10.144.1.224:9000
-      bucket: baas
+      bucket: k8up
       accessKeyIDSecretRef:
         name: backup-credentials
         key: username

--- a/manifest/examples/prometheus/prometheus.yml
+++ b/manifest/examples/prometheus/prometheus.yml
@@ -37,10 +37,10 @@ scrape_configs:
   - role: pod
   relabel_configs:
   - source_labels: [__meta_kubernetes_namespace]
-    regex: appuio-baas-operator
+    regex: appuio-k8up-operator
     action: keep
   - source_labels: [__meta_kubernetes_pod_label_app]
-    regex: baas-operator
+    regex: k8up-operator
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_port_number]
     regex:

--- a/manifest/examples/prune/prune.yaml
+++ b/manifest/examples/prune/prune.yaml
@@ -9,7 +9,7 @@ spec:
   backend:
     s3:
       endpoint: http://10.144.1.224:9000
-      bucket: baas
+      bucket: k8up
       accessKeyIDSecretRef:
         name: backup-credentials
         key: username
@@ -20,4 +20,3 @@ spec:
         name: backup-repo
         key: password
   promURL: http://10.144.1.224:9000
-

--- a/manifest/examples/restore/restoreDisk.yaml
+++ b/manifest/examples/restore/restoreDisk.yaml
@@ -14,7 +14,7 @@ spec:
   backend:
     s3:
       endpoint: http://10.144.1.224:9000
-      bucket: baas
+      bucket: k8up
       accessKeyIDSecretRef:
         name: backup-credentials
         key: username

--- a/manifest/examples/restore/restoreS3.yaml
+++ b/manifest/examples/restore/restoreS3.yaml
@@ -20,7 +20,7 @@ spec:
   backend:
     s3:
       endpoint: http://10.144.1.224:9000
-      bucket: baas
+      bucket: k8up
       accessKeyIDSecretRef:
         name: backup-credentials
         key: username

--- a/manifest/examples/restore/restoreS3Override.yaml
+++ b/manifest/examples/restore/restoreS3Override.yaml
@@ -8,11 +8,10 @@ metadata:
 spec:
   restoreMethod:
     s3:
-      bucket: baas-restore
+      bucket: k8up-restore
   backend:
     repoPasswordSecretRef:
       key: repopw
       name: repopw
     s3:
-      bucket: baas-namespace
-
+      bucket: k8up-namespace

--- a/manifest/examples/schedule/schedule.yaml
+++ b/manifest/examples/schedule/schedule.yaml
@@ -7,7 +7,7 @@ spec:
   backend:
     s3:
       endpoint: http://10.144.1.224:9000
-      bucket: baas
+      bucket: k8up
       accessKeyIDSecretRef:
         name: backup-credentials
         key: username
@@ -41,4 +41,3 @@ spec:
     retention:
       keepLast: 5
       keepDaily: 14
-

--- a/manifest/install/clusterrole-user.yaml
+++ b/manifest/install/clusterrole-user.yaml
@@ -2,7 +2,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: baas-user-edit
+  name: k8up-user-edit
   labels:
     # Add these permissions to the "admin" and "edit" default roles.
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
@@ -18,7 +18,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: baas-user-view
+  name: k8up-user-view
   labels:
     # Add these permissions to the "view" default role.
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/manifest/install/clusterrole.yaml
+++ b/manifest/install/clusterrole.yaml
@@ -2,7 +2,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: baas-operator
+  name: k8up-operator
 rules:
 - apiGroups:
     - apiextensions.k8s.io

--- a/manifest/install/clusterrolebinding.yaml
+++ b/manifest/install/clusterrolebinding.yaml
@@ -2,12 +2,12 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: baas-operator
+  name: k8up-operator
 subjects:
 - kind: ServiceAccount
   namespace: myproject
-  name: baas-operator
+  name: k8up-operator
 roleRef:
   kind: ClusterRole
-  name: baas-operator
+  name: k8up-operator
   apiGroup: rbac.authorization.k8s.io

--- a/manifest/install/operator.yaml
+++ b/manifest/install/operator.yaml
@@ -2,22 +2,22 @@
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: baas
+  name: k8up
   labels:
-    app: baas
+    app: k8up
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: baas
+      app: k8up
   template:
     metadata:
       labels:
-        app: baas
+        app: k8up
     spec:
       containers:
-        - name: baas-operator
-          image: 172.30.1.1:5000/myproject/baas:0.0.1
+        - name: k8up-operator
+          image: 172.30.1.1:5000/myproject/k8up:0.0.1
           imagePullPolicy: Always
           env:
             - name: BACKUP_IMAGE
@@ -39,7 +39,7 @@ spec:
             - name: BACKUP_GLOBALS3ENDPOINT
               value: http://10.144.1.224:9000
             - name: BACKUP_GLOBALS3BUCKET
-              value: baas
-      serviceAccountName: baas-operator
+              value: k8up
+      serviceAccountName: k8up-operator
 
 #kubectl create clusterrolebinding cluster-admin-binding-2   --clusterrole=cluster-admin   --user=system:system:serviceaccount:myproject:default

--- a/manifest/install/service-account.yaml
+++ b/manifest/install/service-account.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: baas-operator
+  name: k8up-operator


### PR DESCRIPTION
Replaces the mentions of `baas` by `k8up` in the manifest files.

**Relates to:** #99 