### PR TITLE
fix: only add ResticPassword if set

### DIFF
--- a/api/v1alpha1/backend.go
+++ b/api/v1alpha1/backend.go
@@ -23,8 +23,10 @@ type Backend struct {
 func (b *Backend) GetCredentialEnv() map[string]*corev1.EnvVarSource {
 	vars := make(map[string]*corev1.EnvVarSource)
 
-	vars[constants.ResticPasswordEnvName] = &corev1.EnvVarSource{
-		SecretKeyRef: b.RepoPasswordSecretRef,
+	if b.RepoPasswordSecretRef != nil {
+		vars[constants.ResticPasswordEnvName] = &corev1.EnvVarSource{
+			SecretKeyRef: b.RepoPasswordSecretRef,
+		}
 	}
 
 	if b.Azure != nil {

--- a/executor/generic.go
+++ b/executor/generic.go
@@ -130,7 +130,6 @@ func DefaultEnv(namespace string) EnvVarConverter {
 	defaults := NewEnvVarConverter()
 
 	defaults.SetString("STATS_URL", constants.GetGlobalStatsURL())
-	defaults.SetString(constants.ResticPasswordEnvName, constants.GetGlobalRepoPassword())
 	defaults.SetString(constants.ResticRepositoryEnvName, fmt.Sprintf("s3:%s/%s", constants.GetGlobalS3Endpoint(), constants.GetGlobalS3Bucket()))
 	defaults.SetString(constants.ResticPasswordEnvName, constants.GetGlobalRepoPassword())
 	defaults.SetString(constants.AwsAccessKeyIDEnvName, constants.GetGlobalAccessKey())

--- a/executor/generic_test.go
+++ b/executor/generic_test.go
@@ -1,0 +1,52 @@
+package executor
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestEnvVarConverter_Merge(t *testing.T) {
+	vars := NewEnvVarConverter()
+	vars.SetString("nooverridestr", "original")
+	vars.SetEnvVarSource("nooverridesrc", &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{Key: "original"}})
+	vars.SetString("nomergestr", "original")
+	vars.SetEnvVarSource("nomergesource", &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{Key: "original"}})
+
+	src := NewEnvVarConverter()
+	src.SetString("nooverridestr", "updated")
+	src.SetEnvVarSource("nooverridestr", &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{Key: "updated"}})
+	src.SetEnvVarSource("nooverridesrc", &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{Key: "updated"}})
+	src.SetString("newstr", "original")
+	src.SetEnvVarSource("newsource", &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{Key: "original"}})
+
+	if err := vars.Merge(src); err != nil {
+		t.Errorf("unable to merge: %v", err)
+	}
+
+	v := vars.Vars
+
+	if *v["nooverridestr"].stringEnv != "original" {
+		t.Error("nooverridestr should not have been updated.")
+	}
+	if v["nooverridestr"].envVarSource != nil {
+		t.Error("nooverridestr should not have been updated.")
+	}
+	if v["nooverridesrc"].envVarSource.SecretKeyRef.Key != "original" {
+		t.Error("nooverridesrc should not have been updated.")
+	}
+
+	if *v["nomergestr"].stringEnv != "original" {
+		t.Error("nomergestr should not have been updated.")
+	}
+	if v["nomergesource"].envVarSource.SecretKeyRef.Key != "original" {
+		t.Error("nomergesource should not have been updated.")
+	}
+
+	if *v["newstr"].stringEnv != "original" {
+		t.Error("newstr should have been merged in.")
+	}
+	if v["newsource"].envVarSource.SecretKeyRef.Key != "original" {
+		t.Error("nomergesource should have been merged in.")
+	}
+}


### PR DESCRIPTION
see #135 for context - @Kidswiss mentioned that the RESTIC_PASSWORD setting is lost with the new implementation. 

I believe this was responsible for the Restic password not being merged correct. As it's been set by default even if the backend didn't specify, the global default wasn't being used instead. 
I added a test to clarify the way Mergo merges. 