### PR TITLE
Integrate KIND into makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,6 @@ bin/
 dist/
 k8up-crd.yaml
 k8up
+testbin/
 
 __debug_bin

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,12 @@ CRD_OPTIONS ?= "crd:trivialVersions=true"
 
 CRD_FILE ?= k8up-crd.yaml
 
+TESTBIN_DIR ?= ./testbin/bin
+KIND_BIN ?= $(TESTBIN_DIR)/kind
+KIND_VERSION ?= 0.9.0
+KIND_KUBECONFIG ?= ./testbin/kind-kubeconfig
+KIND_CLUSTER ?= k8up
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -28,11 +34,25 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+# Set Shell to bash, otherwise some targets fail with dash/zsh etc.
+SHELL := /bin/bash
+
 all: build
 
 # Run tests
 test: generate fmt vet manifests
 	go test ./... -coverprofile cover.out
+
+# Run tests (see https://sdk.operatorframework.io/docs/building-operators/golang/references/envtest-setup)
+ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
+
+$(TESTBIN_DIR):
+	mkdir -p $(TESTBIN_DIR)
+
+integration_test: export ENVTEST_K8S_VERSION = 1.19.0
+integration_test: generate fmt vet manifests $(TESTBIN_DIR)
+	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/hack/setup-envtest.sh
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test -tags=integration -v ./... -coverprofile cover.out
 
 # Build manager binary
 build: generate fmt vet
@@ -61,6 +81,7 @@ deploy: manifests kustomize
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	@go run hack/patch-crd-compatibility.go config/crd/bases/backup.appuio.ch_prebackuppods.yaml
 
 # Generate CRD to file
 crd: manifests kustomize
@@ -135,3 +156,24 @@ bundle: manifests
 .PHONY: bundle-build
 bundle-build:
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+
+setup_e2e_test: export KUBECONFIG = $(KIND_KUBECONFIG)
+setup_e2e_test: $(KIND_BIN) manifests
+	@kubectl config use-context kind-$(KIND_CLUSTER)
+	@kubectl apply -k config/crd
+
+run_kind: export KUBECONFIG = $(KIND_KUBECONFIG)
+run_kind: setup_e2e_test
+	go run ./main.go
+
+$(KIND_BIN): export KUBECONFIG = $(KIND_KUBECONFIG)
+$(KIND_BIN): $(TESTBIN_DIR)
+	curl -Lo $(KIND_BIN) "https://kind.sigs.k8s.io/dl/v$(KIND_VERSION)/kind-$$(uname)-amd64"
+	chmod +x $(KIND_BIN)
+	$(KIND_BIN) create cluster --name $(KIND_CLUSTER)
+	kubectl cluster-info
+
+clean: export KUBECONFIG = $(KIND_KUBECONFIG)
+clean:
+	$(KIND_BIN) delete cluster --name $(KIND_CLUSTER) || true
+	rm -r testbin/ dist/ bin/ cover.out k8up || true

--- a/README.md
+++ b/README.md
@@ -52,11 +52,12 @@ Therefore settle to the second approach for now.
 
 ## Run the operator
 
-You can run the operator in three different ways:
+You can run the operator in different ways:
 
 1. as a docker image (see [quickstart](https://sdk.operatorframework.io/docs/building-operators/golang/quickstart/))
-2. using `make run`
-3. using a configuration of your favorite IDE (see below for VSCode example)
+2. using `make run` (provide your own kubeconfig)
+3. using `make run_kind` (uses KIND to install a cluster in docker and provides its own kubeconfig in `testbin/`)
+4. using a configuration of your favorite IDE (see below for VSCode example)
 
 Example VSCode run configuration:
 

--- a/config/crd/bases/backup.appuio.ch_prebackuppods.yaml
+++ b/config/crd/bases/backup.appuio.ch_prebackuppods.yaml
@@ -1273,7 +1273,6 @@ spec:
                             type: array
                             x-kubernetes-list-map-keys:
                             - containerPort
-                            - protocol
                             x-kubernetes-list-type: map
                           readinessProbe:
                             description: 'Periodic probe of container service readiness.
@@ -3591,7 +3590,6 @@ spec:
                             type: array
                             x-kubernetes-list-map-keys:
                             - containerPort
-                            - protocol
                             x-kubernetes-list-type: map
                           readinessProbe:
                             description: 'Periodic probe of container service readiness.

--- a/hack/patch-crd-compatibility.go
+++ b/hack/patch-crd-compatibility.go
@@ -1,0 +1,70 @@
+// +build fix-crd
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+)
+
+// controller-gen 0.3 creates CRDs with apiextensions.k8s.io/v1beta1, but some generated properties aren't valid for that version
+// in K8s 1.18+. We would have to switch to apiextensions.k8s.io/v1, but that would make the CRD incompatible with OpenShift 3.11.
+// So we have to patch the CRD in post-generation.
+// See https://github.com/kubernetes/kubernetes/issues/91395
+func main() {
+	fileName := os.Args[1]
+	log.Println(fmt.Sprintf("Reading file %s", fileName))
+	lines, err := readLines(fileName)
+	if err != nil {
+		log.Fatalf("readLines: %s", err)
+	}
+	count := 0
+	var result []string
+	for i, line := range lines {
+		if line == "                            - protocol" {
+			count++
+			log.Println(fmt.Sprintf("Removed 'protocol' in line %d", i))
+		} else {
+			result = append(result, line)
+		}
+	}
+
+	log.Println(fmt.Sprintf("Writing new file to %s", fileName))
+	if err := writeLines(result, fileName); err != nil {
+		log.Fatalf("writeLines: %s", err)
+	}
+}
+
+// readLines reads a whole file into memory
+// and returns a slice of its lines.
+func readLines(path string) ([]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	return lines, scanner.Err()
+}
+
+// writeLines writes the lines to the given file.
+func writeLines(lines []string, path string) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	w := bufio.NewWriter(file)
+	for _, line := range lines {
+		fmt.Fprintln(w, line)
+	}
+	return w.Flush()
+}


### PR DESCRIPTION
* Integrates KIND into makefile, just run `make run_kind` and it will
  * Install the CRDs
  * Run the Operator with this kubeconfig
* Makes the CRD compatible with K8s v1.18 again (the CRD generated was invalid):
```
The CustomResourceDefinition "prebackuppods.backup.appuio.ch" is invalid: 
* spec.validation.openAPIV3Schema.properties[spec].properties[pod].properties[spec].properties[initContainers].items.properties[ports].items.properties[protocol].default: Required value: this property is in x-kubernetes-list-map-keys, so it must have a default or be a required property
* spec.validation.openAPIV3Schema.properties[spec].properties[pod].properties[spec].properties[containers].items.properties[ports].items.properties[protocol].default: Required value: this property is in x-kubernetes-list-map-keys, so it must have a default or be a required property
make: *** [Makefile:163: setup_e2e_test] Error 1
```