### PR TITLE
Add e2e test with bats-detik

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Run e2e tests
-      run: make crd e2e_test -e CRD_SPEC_VERSION=${{ matrix.crd-spec-version }} -e KIND_NODE_VERSION=${{ matrix.kind-node-version }} -e KIND_KUBECTL_ARGS=--validate=false
+      run: make crd install_bats setup_e2e_test e2e_test -e CRD_SPEC_VERSION=${{ matrix.crd-spec-version }} -e KIND_NODE_VERSION=${{ matrix.kind-node-version }} -e KIND_KUBECTL_ARGS=--validate=false
+    - name: Show e2e debug logs
+      run: cat e2e/debug/detik/*
   image:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,6 @@ dist/
 k8up-crd*.yaml
 k8up
 testbin/
-
+node_modules/
+e2e/debug
 __debug_bin

--- a/README.md
+++ b/README.md
@@ -92,8 +92,14 @@ Best is if you have [minio](https://min.io/download) installed somewhere to be a
 
 ## Run E2E tests
 
-K8up supports both OpenShift 3.11 clusters and newer Kubernetes clusters 1.16+. 
+K8up supports both OpenShift 3.11 clusters and newer Kubernetes clusters 1.16+.
 However, to support OpenShift 3.11 a legacy CRD definition with `apiextensions.k8s.io/v1beta1` is needed, while K8s 1.22+ only supports `apiextensions.k8s.io/v1`.
+You need `node` and `npm` to run the tests, as it runs with [DETIK][detik].
+
+First, setup a local e2e environment
+```
+make install_bats setup_e2e_test
+```
 
 To run e2e tests for newer K8s versions run
 ```
@@ -103,7 +109,12 @@ make e2e_test
 To test compatibility of k8up with OpenShift 3.11, we can run end-to-end tests as following:
 ```
 make e2e_test -e CRD_SPEC_VERSION=v1beta1 -e KIND_NODE_VERSION=v1.13.12
-``` 
+```
+
+To remove the local KIND cluster and other resources, run
+```
+make clean
+```
 
 ## Example configurations
 
@@ -113,3 +124,4 @@ There are a number of example configurations in [`config/samples`](config/sample
 [releases]: https://github.com/vshn/k8up/releases
 [license]: https://github.com/vshn/k8up/blob/master/LICENSE
 [dockerhub]: https://hub.docker.com/r/vshn/k8up
+[detik]: https://github.com/bats-core/bats-detik

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -1,0 +1,14 @@
+
+# Set Shell to bash, otherwise some targets fail with dash/zsh etc.
+SHELL := /bin/bash
+
+install_bats:
+	@npm install
+
+run_bats: export KUBECONFIG = $(KIND_KUBECONFIG)
+run_bats:
+	@mkdir debug || true
+	@node_modules/.bin/bats .
+
+clean:
+	rm -r debug node_modules || true

--- a/e2e/kind-config.yaml
+++ b/e2e/kind-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
+    endpoint = ["http://kind-registry:5000"]

--- a/e2e/lib/detik.bash
+++ b/e2e/lib/detik.bash
@@ -1,0 +1,286 @@
+#!/bin/bash
+
+directory=$(dirname "${BASH_SOURCE[0]}")
+source "$directory/utils.bash"
+
+
+# Retrieves values and attempts to compare values to an expected result (with retries).
+# @param {string} A text query that respect the appropriate syntax
+# @return
+#	1 Empty query
+#	2 Invalid syntax
+#	3 The assertion could not be verified after all the attempts
+#	  (may also indicate an error with the K8s client)
+#	0 Everything is fine
+try() {
+
+	# Concatenate all the arguments into a single string
+	IFS=' '
+	exp="$*"
+
+	# Trim the expression
+	exp=$(trim "$exp")
+
+	# Make the regular expression case-insensitive
+	shopt -s nocasematch;
+
+	# Verify the expression and use it to build a request
+	if [[ "$exp" == "" ]]; then
+		echo "An empty expression was not expected."
+		return 1
+	fi
+
+	# Let's verify the syntax
+	times=""
+	delay=""
+	resource=""
+	name=""
+	property=""
+	expected_value=""
+	expected_count=""
+
+	if [[ "$exp" =~ $try_regex_verify ]]; then
+
+		# Extract parameters
+		times="${BASH_REMATCH[1]}"
+		delay="${BASH_REMATCH[2]}"
+		resource=$(to_lower_case "${BASH_REMATCH[3]}")
+		name="${BASH_REMATCH[4]}"
+		property="${BASH_REMATCH[5]}"
+		expected_value=$(to_lower_case "${BASH_REMATCH[6]}")
+
+	elif [[ "$exp" =~ $try_regex_find ]]; then
+
+		# Extract parameters
+		times="${BASH_REMATCH[1]}"
+		delay="${BASH_REMATCH[2]}"
+		expected_count="${BASH_REMATCH[3]}"
+		resource=$(to_lower_case "${BASH_REMATCH[4]}")
+		name="${BASH_REMATCH[5]}"
+		property="${BASH_REMATCH[6]}"
+		expected_value=$(to_lower_case "${BASH_REMATCH[7]}")
+	fi
+
+	# Do we have something?
+	if [[ "$times" != "" ]]; then
+
+		# Prevent line breaks from being removed in command results
+		IFS=""
+
+		# Start the loop
+		echo "Valid expression. Verification in progress..."
+		code=0
+		for ((i=1; i<=$times; i++)); do
+
+			# Verify the value
+			verify_value $property $expected_value $resource $name "$expected_count" && code=$? || code=$?
+
+			# Break the loop prematurely?
+			if [[ "$code" == "0" ]]; then
+				break
+      elif [[ "$code" == "101" ]]; then
+        sleep $delay
+			elif [[ "$i" != "1" ]]; then
+				code=3
+				sleep $delay
+			else
+				code=3
+			fi
+		done
+
+		## Error code
+		return $code
+	fi
+
+	# Default behavior
+	echo "Invalid expression: it does not respect the expected syntax."
+	return 2
+}
+
+
+# Retrieves values and attempts to compare values to an expected result (without any retry).
+# @param {string} A text query that respect one of the supported syntaxes
+# @return
+#	1 Empty query
+#	2 Invalid syntax
+#	3 The elements count is incorrect
+#	  (may also indicate an error with the K8s client)
+#	0 Everything is fine
+verify() {
+
+	# Concatenate all the arguments into a single string
+	IFS=' '
+	exp="$*"
+
+	# Trim the expression
+	exp=$(trim "$exp")
+
+	# Make the regular expression case-insensitive
+	shopt -s nocasematch;
+
+	# Verify the expression and use it to build a request
+	if [[ "$exp" == "" ]]; then
+		echo "An empty expression was not expected."
+		return 1
+
+	elif [[ "$exp" =~ $verify_regex_count_is ]] || [[ "$exp" =~ $verify_regex_count_are ]]; then
+		card="${BASH_REMATCH[1]}"
+		resource=$(to_lower_case "${BASH_REMATCH[2]}")
+		name="${BASH_REMATCH[3]}"
+
+		echo "Valid expression. Verification in progress..."
+		query=$(build_k8s_request "")
+		client_with_options=$(build_k8s_client_with_options)
+		result=$(eval $client_with_options get $resource $query | grep $name | tail -n +1 | wc -l | tr -d '[:space:]')
+
+		# Debug?
+		detik_debug "-----DETIK:begin-----"
+		detik_debug "$BATS_TEST_FILENAME"
+		detik_debug "$BATS_TEST_DESCRIPTION"
+		detik_debug ""
+		detik_debug "Client query:"
+		detik_debug "$client_with_options get $resource $query"
+		detik_debug ""
+		detik_debug "Result:"
+		detik_debug "$result"
+		detik_debug "-----DETIK:end-----"
+		detik_debug ""
+
+		if [[ "$result" == "$card" ]]; then
+			echo "Found $result $resource named $name (as expected)."
+		else
+			echo "Found $result $resource named $name (instead of $card expected)."
+			return 3
+		fi
+
+	elif [[ "$exp" =~ $verify_regex_property_is ]]; then
+		property="${BASH_REMATCH[1]}"
+		expected_value="${BASH_REMATCH[2]}"
+		resource=$(to_lower_case "${BASH_REMATCH[3]}")
+		name="${BASH_REMATCH[4]}"
+
+		echo "Valid expression. Verification in progress..."
+		verify_value $property $expected_value $resource $name
+
+		if [[ "$?" != "0" ]]; then
+			return 3
+		fi
+
+	else
+		echo "Invalid expression: it does not respect the expected syntax."
+		return 2
+	fi
+}
+
+
+# Verifies the value of a column for a set of elements.
+# @param {string} A K8s column or one of the supported aliases.
+# @param {string} The expected value.
+# @param {string} The resouce type (e.g. pod).
+# @param {string} The resource name or regex.
+# @param {integer} a.k.a. "expected_count": the expected number of elements having this property (optional)
+# @return
+# 		If "expected_count" was NOT set: the number of elements with the wrong value.
+#		If "expected_count" was set: 101 if the elements count is not right, 0 otherwise.
+verify_value() {
+
+	# Make the parameters readable
+	property="$1"
+	expected_value=$(to_lower_case "$2")
+	resource="$3"
+	name="$4"
+	expected_count="$5"
+
+	# List the items and remove the first line (the one that contains the column names)
+	query=$(build_k8s_request $property)
+	client_with_options=$(build_k8s_client_with_options)
+	result=$(eval $client_with_options get $resource $query | grep $name | tail -n +1)
+
+	# Debug?
+	detik_debug "-----DETIK:begin-----"
+	detik_debug "$BATS_TEST_FILENAME"
+	detik_debug "$BATS_TEST_DESCRIPTION"
+	detik_debug ""
+	detik_debug "Client query:"
+	detik_debug "$client_with_options get $resource $query"
+	detik_debug ""
+	detik_debug "Result:"
+	detik_debug "$result"
+	if [[ "$expected_count" != "" ]]; then
+		detik_debug ""
+		detik_debug "Expected count: $expected_count"
+	fi
+	detik_debug "-----DETIK:end-----"
+	detik_debug ""
+
+	# Is the result empty?
+	empty=0
+	if [[ "$result" == "" ]]; then
+		echo "No resource of type '$resource' was found with the name '$name'."
+	fi
+
+	# Verify the result
+	IFS=$'\n'
+	invalid=0
+	valid=0
+	for line in $result; do
+
+		# Keep the second column (property to verify)
+		# and put it in lower case
+		value=$(to_lower_case "$line" | awk '{ print $2 }')
+		element=$(echo "$line" | awk '{ print $1 }')
+		if [[ "$value" != "$expected_value" ]]; then
+			echo "Current value for $element is $value..."
+			invalid=$((invalid + 1))
+		else
+			echo "$element has the right value ($value)."
+			valid=$((valid + 1))
+		fi
+	done
+
+	# Do we have the right number of elements?
+	if [[ "$expected_count" != "" ]]; then
+		if [[ "$valid" != "$expected_count" ]]; then
+			echo "Expected $expected_count $resource named $name to have this value ($expected_value). Found $valid."
+			invalid=101
+		else
+			invalid=0
+		fi
+	fi
+
+	return $invalid
+}
+
+
+# Builds the request for the get operation of the K8s client.
+# @param {string} A K8s column or one of the supported aliases.
+# @return 0
+build_k8s_request() {
+
+	req="-o custom-columns=NAME:.metadata.name"
+	if [[ "$1" == "status" ]]; then
+		req="$req,PROP:.status.phase"
+	elif [[ "$1" == "port" ]]; then
+		req="$req,PROP:.spec.ports[*].port"
+	elif [[ "$1" == "targetPort" ]]; then
+		req="$req,PROP:.spec.ports[*].targetPort"
+	elif [[ "$1" != "" ]]; then
+		req="$req,PROP:$1"
+	fi
+
+	echo $req
+}
+
+
+# Builds the client command, with the option for the K8s namespace, if any.
+# @return 0
+build_k8s_client_with_options() {
+
+	client_with_options="$DETIK_CLIENT_NAME"
+	if [[ ! -z "$DETIK_CLIENT_NAMESPACE" ]]; then
+		# eval does not like '-n'
+		client_with_options="$DETIK_CLIENT_NAME --namespace=$DETIK_CLIENT_NAMESPACE"
+	fi
+
+	echo $client_with_options
+}

--- a/e2e/lib/k8up.bash
+++ b/e2e/lib/k8up.bash
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+setup() {
+  debug "-- $BATS_TEST_DESCRIPTION"
+  debug "-- $(date)"
+  debug ""
+  debug ""
+}
+
+teardown() {
+  cp -r /tmp/detik debug || true
+}

--- a/e2e/lib/linter.bash
+++ b/e2e/lib/linter.bash
@@ -1,0 +1,244 @@
+#!/bin/bash
+
+directory=$(dirname "${BASH_SOURCE[0]}")
+source "$directory/utils.bash"
+
+
+# Constants
+lint_try_regex="^(run[[:space:]]+)?[[:space:]]*try[[:space:]]+(.*)$"
+lint_verify_regex="^(run[[:space:]]+)?[[:space:]]*verify[[:space:]]+(.*)$"
+
+# Global variables
+errors_count=0
+verified_entries_count=0
+
+
+# Verifies the syntax of DETIK queries.
+# @param {string} A file path
+# @return
+#	Any integer above 0: the number of found errors
+#	0 Everything is fine
+lint() {
+
+	# Verify the file exists
+	if [ ! -f "$1" ]; then
+		handle_error "'$1' does not exist or is not a regular file."
+		return 1
+	fi
+	
+	# Make the regular expression case-insensitive
+	shopt -s nocasematch;
+
+	current_line=""
+	current_line_number=0
+	user_line_number=0
+	multi_line=1
+	was_multi_line=1
+	while IFS='' read -r line || [[ -n "$line" ]]; do
+
+		# Increase the line number
+		current_line_number=$((current_line_number + 1))
+		
+		# Debug
+		detik_debug "Read line $current_line_number: $line"
+		
+		# Skip empty lines and comments
+		if [[ ! -n "$line" ]] || [[ "$line" =~ ^[[:space:]]*#.* ]]; then
+			if [[ "$multi_line" == "0" ]]; then
+				handle_error "Incomplete multi-line statement at $current_line_number."
+				$current_line=""
+			fi
+			continue
+		fi
+		
+		# Is this line a part of a multi-line statement?
+		was_multi_line="$multi_line"
+		[[ "$line" =~ ^.*\\$ ]]
+		multi_line="$?"
+		
+		# Do we need to update the user line number?
+		if [[ "$was_multi_line" != "0" ]]; then
+			user_line_number="$current_line_number"
+		fi
+
+		# Is this the continuation of a previous line?
+		if [[ "$multi_line" == "0" ]]; then
+			current_line="$current_line ${line::-1}"
+		elif [[ "$was_multi_line" == "0" ]]; then
+			current_line="$current_line $line"
+		else
+			current_line="$line"
+		fi
+		
+		# When we have a complete line...
+		if [[ "$multi_line" != "0" ]]; then
+			check_line "$current_line" "$user_line_number"
+			current_line=""
+		fi
+		line=""
+	done < "$1"
+
+	# Output
+	if [[ "$verified_entries_count" == "1" ]]; then
+		echo "1 DETIK query was verified."
+	else
+		echo "$verified_entries_count DETIK queries were verified."
+	fi
+	
+	if [[ "$errors_count" == "1" ]]; then
+		echo "1 DETIK query was found to be invalid or malformed."
+	else
+		echo "$errors_count DETIK queries were found to be invalid or malformed."
+	fi
+
+	# Prepare the result
+	res="$errors_count"
+	
+	# Reset global variables
+	errors_count=0
+	verified_entries_count=0
+
+	return "$res"
+}
+
+
+# Verifies the correctness of a read line.
+# @param {string} The line to verify
+# @param {integer} The line number
+# @return 0
+check_line() {
+
+	# Make the regular expression case-insensitive
+	shopt -s nocasematch;
+
+	# Get parameters and prepare the line
+	line="$1"
+	line_number="$2"
+	context="Current line: $line"
+	
+	line=$(echo "$line" | sed -e 's/"[[:space:]]*"//g')
+	line=$(trim "$line")
+	context="$context\nPurged line:  $line"
+	
+	# Basic case: "run try", "run verify", "try", "verify" alone
+	if [[ "$line" =~ ^(run[[:space:]]+)?try$ ]] || [[ "$line" =~ ^(run[[:space:]]+)?verify$ ]]; then
+		verified_entries_count=$((verified_entries_count + 1))
+		handle_error "Empty statement at line $line_number." "$context"
+	
+	# We have "try" or "run try" followed by something
+	elif [[ "$line" =~ $lint_try_regex ]]; then
+		verified_entries_count=$((verified_entries_count + 1))
+		
+		part=$(clean_regex_part "${BASH_REMATCH[2]}")
+		context="$context\nRegex part:  $part"
+
+		verify_against_pattern "$part" "$try_regex_verify"
+		p_verify="$?"
+		
+		verify_against_pattern "$part" "$try_regex_find"
+		p_find="$?"
+		
+		# detik_debug "p_verify=$p_verify, p_find=$p_find, part=$part"
+		if [[ "$p_verify" != "0" ]] && [[ "$p_find" != "0" ]]; then
+			handle_error "Invalid TRY statement at line $line_number." "$context"
+		fi
+
+	# We have "verify" or "run verify" followed by something
+	elif [[ "$line" =~ $lint_verify_regex ]]; then
+		verified_entries_count=$((verified_entries_count + 1))
+		
+		part=$(clean_regex_part "${BASH_REMATCH[2]}")
+		context="$context\nRegex part:  $part"
+
+		verify_against_pattern "$part" "$verify_regex_count_is"
+		p_is="$?"
+		
+		verify_against_pattern "$part" "$verify_regex_count_are"
+		p_are="$?"
+		
+		verify_against_pattern "$part" "$verify_regex_property_is"
+		p_prop="$?"
+		
+		# detik_debug "p_is=$p_is, p_are=$p_are, p_prop=$p_prop, part=$part"
+		if [[ "$p_is" != "0" ]] && [[ "$p_are" != "0" ]]  && [[ "$p_prop" != "0" ]] ; then
+			handle_error "Invalid VERIFY statement at line $line_number." "$context"
+		fi
+	fi
+}
+
+
+# Cleans a string before being checked by a regexp.
+# @param {string} The string to clean
+# @return 0
+clean_regex_part() {
+
+	part=$(trim "$1")
+	part=$(remove_surrounding_quotes "$part")
+	part=$(trim "$part")
+	echo "$part"
+}
+
+
+# Removes surrounding quotes.
+# @param {string} The string to clean
+# @return 0
+remove_surrounding_quotes() {
+
+	# Starting and ending with a quote? Remove them.
+	if [[ "$1" =~ ^\"(.*)\"$ ]]; then
+		echo "${BASH_REMATCH[1]}"
+	
+	# Otherwise, ignore it
+	else
+		echo "$1"
+	fi
+	
+	return 0
+}
+
+
+# Verifies an assertion part against a regular expression.
+# Given that assertions can skip double quotes around the whole
+# assertion, we try the given regular expression and an altered one.
+#
+# Example: run try at most 5 times ... "'nginx'" ...
+#
+# Here, "'nginx'" is not part of the default regular expression.
+# So, we update it to allow this kind of assertions.
+#
+# @param {string} The line to verify
+# @param {string} The pattern
+# @return
+#	0 if everyhing went fine
+#	not-zero in case of error
+verify_against_pattern() {
+
+	# Make the regular expression case-insensitive
+	shopt -s nocasematch;
+
+	line="$1"
+	pattern="$2"
+	code=0
+	if ! [[ "$line" =~ $pattern ]]; then
+		line=${line//\"\'/\'}
+		line=${line//\'\"/\'}
+		[[ "$line" =~ $pattern ]]
+		code="$?"
+	fi
+	
+	return "$code"
+}
+
+
+# Handles an error by printing it and updating the error count.
+# @param {string} The error message
+# @param2 {string} The error context
+# @return 0
+handle_error() {
+
+	detik_debug "$2"
+	detik_debug "Error: $1"
+
+	echo "$1"
+	errors_count=$((errors_count + 1))
+}

--- a/e2e/lib/utils.bash
+++ b/e2e/lib/utils.bash
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+
+# The regex for the "try" key word
+try_regex_verify="^at +most +([0-9]+) +times +every +([0-9]+)s +to +get +([a-z]+) +named +'([^']+)' +and +verify +that +'([^']+)' +is +'([^']+)'$"
+try_regex_find="^at +most +([0-9]+) +times +every +([0-9]+)s +to +find +([0-9]+) +([a-z]+) +named +'([^']+)' +with +'([^']+)' +being +'([^']+)'$"
+
+# The regex for the "verify" key word
+verify_regex_count_is="^there +is +(0|1) +([a-z]+) +named +'([^']+)'$"
+verify_regex_count_are="^there +are +([0-9]+) +([a-z]+) +named +'([^']+)'$"
+verify_regex_property_is="^'([^']+)' +is +'([^']+)' +for +([a-z]+) +named +'([^']+)'$"
+
+
+
+# Prints a string in lower case.
+# @param {string} The string.
+# @return 0
+to_lower_case() {
+	echo "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+
+# Trims a text.
+# @param {string} The string.
+# @return 0
+trim() {
+	echo $1 | sed -e 's/^[[:space:]]*([^[[:space:]]].*[^[[:space:]]])[[:space:]]*$/$1/'
+}
+
+
+# Trims ANSI codes (used to format strings in consoles).
+# @param {string} The string.
+# @return 0
+trim_ansi_codes() {
+	echo $1 | sed -e 's/[[:cntrl:]]\[[0-9;]*[a-zA-Z]//g'
+}
+
+
+# Adds a debug message for a given test.
+# @param {string} The debug message.
+# @return 0
+debug() {
+	debug_filename=$(basename -- $BATS_TEST_FILENAME)
+	mkdir -p /tmp/detik
+	echo -e "$1" >> "/tmp/detik/$debug_filename.debug"
+}
+
+
+# Deletes the file that contains debug messages for a given test.
+# @return 0
+reset_debug() {
+	debug_filename=$(basename -- $BATS_TEST_FILENAME)
+	rm -f "/tmp/detik/$debug_filename.debug"
+}
+
+
+# Adds a debug message for a given test about DETIK.
+# @param {string} The debug message.
+# @return 0
+detik_debug() {
+
+	if [[ "$DEBUG_DETIK" == "true" ]]; then
+		debug "$1"
+        fi
+}
+
+
+# Deletes the file that contains debug messages for a given test about DETIK.
+# @return 0
+reset_detik_debug() {
+
+	if [[ "$DEBUG_DETIK" == "true" ]]; then
+		reset_debug
+	fi
+}

--- a/e2e/lint.bats
+++ b/e2e/lint.bats
@@ -1,0 +1,11 @@
+#!/usr/bin/env bats
+load "lib/utils"
+load "lib/linter"
+
+@test "lint assertions" {
+
+	run lint "test1.bats"
+	# echo -e "$output" > /tmp/errors.txt
+	[ "$status" -eq 0 ]
+
+}

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "k8up",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "bats": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bats/-/bats-1.2.1.tgz",
+      "integrity": "sha512-2fcPDRQa/Kvh6j1IcCqsHpT5b9ObMzRzw6abC7Bg298PX8Qdh9VRkvO2WJUEhdyfjq2rLBCOAWdcv0tS4+xTUA==",
+      "dev": true
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "k8up",
+  "devDependencies": {
+    "bats": "^1.2.1"
+  }
+}

--- a/e2e/test1.bats
+++ b/e2e/test1.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+load "lib/utils"
+load "lib/detik"
+load "lib/k8up"
+
+DETIK_CLIENT_NAME="kubectl"
+DETIK_CLIENT_NAMESPACE="k8up-system"
+DEBUG_DETIK="true"
+
+@test "reset the debug file" {
+	reset_debug
+}
+
+@test "verify the deployment" {
+  go run sigs.k8s.io/kustomize/kustomize/v3 build test1 > debug/test1.yaml
+  run kubectl apply -f debug/test1.yaml
+  echo "$output"
+
+  try "at most 20 times every 2s to find 1 pod named 'k8up-operator' with 'status' being 'running'"
+
+}

--- a/e2e/test1/deployment.yaml
+++ b/e2e/test1/deployment.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: operator
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: k8up
+        image: localhost:5000/vshn/k8up:e2e

--- a/e2e/test1/kustomization.yaml
+++ b/e2e/test1/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+- ../../config/manager
+- ../../config/rbac
+patchesStrategicMerge:
+- deployment.yaml
+namespace: k8up-system
+namePrefix: k8up-
+
+commonLabels:
+  app.kubernetes.io/name: e2e
+  app.kubernetes.io/managed-by: kustomize


### PR DESCRIPTION
It took while with try-and-error, but I got it running

This PR adds e2e testing libary and 1 e2e test. 
The setup process is as following:

1. Install BATS (requires local node and npm, which is a prerequisite)
2. Start a local docker registry in docker
3. Install KIND and set up a KIND cluster just for K8up
4. Connect the KIND cluster with the docker registry

Now the initial setup is done (only to be done once). For each e2e test run, we

1. Push the local docker image to the local docker registry, so that KIND can pull the image from local registry
2. Execute BATS
    * which installs the Operator with Kustomize including CRDs
    * it means we are actually testing our container image and deployment
3. Assert outcome with the Syntax that DETIK provides

The current single test case verifies if the Operator can be started from a Deployment (Pod status "running"), but does not do anything else yet. But from this point on it should be trivial to add more assertions that specifically check for logs, status fields in objects etc.

The bash files in `e2e/lib` are vendored (with exception of `e2e/lib/k8up.bash`) and coming from https://github.com/bats-core/bats-detik/tree/master/lib, but I have not created a make target that updates a newer download of it.

This should be executed for both K8s 1.18+ and Openshift-compatible 1.13 (GH action takes care of that)

One thing to note is that by now this e2e test in GH takes between 3 and 5 minutes to run.

Links:
- https://kind.sigs.k8s.io/docs/user/local-registry/
- https://github.com/bats-core/bats-detik
- https://stackoverflow.com/questions/1789594/how-do-i-write-the-cd-command-in-a-makefile