### PR TITLE
Adjust the exclusivity of the restore and archive job

### DIFF
--- a/executor/archive.go
+++ b/executor/archive.go
@@ -56,11 +56,6 @@ func (a *ArchiveExecutor) Execute() error {
 	return nil
 }
 
-// Exclusive should return true for jobs that can't run while other jobs run.
-func (*ArchiveExecutor) Exclusive() bool {
-	return true
-}
-
 func (a *ArchiveExecutor) startArchive(job *batchv1.Job, archive *k8upv1alpha1.Archive) {
 	name := types.NamespacedName{Namespace: a.Obj.GetMetaObject().GetNamespace(), Name: a.Obj.GetMetaObject().GetName()}
 	a.setArchiveCallback(name, archive)

--- a/executor/restore.go
+++ b/executor/restore.go
@@ -51,11 +51,6 @@ func (r *RestoreExecutor) Execute() error {
 	return nil
 }
 
-// Exclusive should return true for jobs that can't run while other jobs run.
-func (r *RestoreExecutor) Exclusive() bool {
-	return true
-}
-
 func (r *RestoreExecutor) startRestore(restore *k8upv1alpha1.Restore) {
 	name := types.NamespacedName{Namespace: r.Obj.GetMetaObject().GetNamespace(), Name: r.Obj.GetMetaObject().GetName()}
 	r.setRestoreCallback(name, restore)

--- a/executor/restore_test.go
+++ b/executor/restore_test.go
@@ -276,7 +276,7 @@ func jobMatcher(restoreType string, additionalArgs []string, env Elements, volum
 		"ObjectMeta": MatchFields(IgnoreExtras, Fields{
 			"Labels": MatchAllKeys(Keys{
 				"k8upjob":           Equal("true"),
-				"k8upjob/exclusive": Equal("true"),
+				"k8upjob/exclusive": Equal("false"),
 			}),
 		}),
 		"Spec": MatchFields(IgnoreExtras, Fields{


### PR DESCRIPTION
Restores aren't exclusive in upstream Restic:
https://github.com/restic/restic/blob/master/cmd/restic/cmd_restore.go#L105

The exclusivity of the various job types should match what's defined in
the upstream Restic project.

Resolves: #173