### PR TITLE
Move "Leader-election" CLI flag to Env var

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -50,6 +50,9 @@ type Configuration struct {
 	PodFilter                        string `koanf:"podfilter"`
 	PromURL                          string `koanf:"promurl"`
 	RestartPolicy                    string `koanf:"restartpolicy"`
+
+	// Enabling this will ensure there is only one active controller manager.
+	EnableLeaderElection bool `koanf:"enable-leader-election"`
 }
 
 var (
@@ -71,6 +74,7 @@ func NewDefaultConfig() *Configuration {
 		RestartPolicy:           "OnFailure",
 		MetricsBindAddress:      ":8080",
 		PodFilter:               "backupPod=true",
+		EnableLeaderElection:    true,
 	}
 }
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,8 +23,6 @@ spec:
       containers:
       - name: k8up
         image: quay.io/vshn/k8up:latest
-        args:
-        - --enable-leader-election=true
         resources:
           limits:
             cpu: 300m

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"os"
 	"strings"
 
@@ -47,12 +46,6 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
-	var enableLeaderElection bool
-	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
-		"Enable leader election for controller manager. "+
-			"Enabling this will ensure there is only one active controller manager.")
-	flag.Parse()
-
 	loadEnvironmentVariables()
 
 	executor.GetExecutor()
@@ -61,7 +54,7 @@ func main() {
 		Scheme:             scheme,
 		MetricsBindAddress: cfg.Config.MetricsBindAddress,
 		Port:               9443,
-		LeaderElection:     enableLeaderElection,
+		LeaderElection:     cfg.Config.EnableLeaderElection,
 		LeaderElectionID:   "d2ab61da.syn.tools",
 	})
 	if err != nil {


### PR DESCRIPTION
It doesn't make much sense to have CLI flags when most of the config is provided via Env vars.