### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[Makefile]
+indent_style = tab
+
+[{*.go, go.mod, *.bats, *.bash}]
+indent_style = tab
+
+[{*.yml, *.json, *.css, *.js}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
I propose to add this `.editorconfig` to establish consistent indention, line ending and end-of-file rules. [Most editors are aware or can be made aware of `.editorconfig`](https://editorconfig.org/#download) and thous automatically apply these rules.

I've tried my best to infer the rules from the lived rules based on the files I've seen.