### PR TITLE
Micro Enhancements

### DIFF
--- a/api/v1alpha1/prune_types.go
+++ b/api/v1alpha1/prune_types.go
@@ -38,7 +38,7 @@ type RetentionPolicy struct {
 	// Tags is a filter on what tags the policy should be applied
 	// DO NOT CONFUSE THIS WITH KeepTags OR YOU'LL have a bad time
 	Tags []string `json:"tags,omitempty"`
-	// Hosntames is a filter on what hostnames the policy should be applied
+	// Hostnames is a filter on what hostnames the policy should be applied
 	Hostnames []string `json:"hostnames,omitempty"`
 }
 

--- a/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_prunes.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_prunes.yaml
@@ -269,7 +269,7 @@ spec:
                 description: Retention sets how many backups should be kept after a forget and prune
                 properties:
                   hostnames:
-                    description: Hosntames is a filter on what hostnames the policy should be applied
+                    description: Hostnames is a filter on what hostnames the policy should be applied
                     items:
                       type: string
                     type: array

--- a/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_schedules.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_schedules.yaml
@@ -1284,7 +1284,7 @@ spec:
                     description: Retention sets how many backups should be kept after a forget and prune
                     properties:
                       hostnames:
-                        description: Hosntames is a filter on what hostnames the policy should be applied
+                        description: Hostnames is a filter on what hostnames the policy should be applied
                         items:
                           type: string
                         type: array

--- a/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_prunes.yaml
+++ b/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_prunes.yaml
@@ -269,7 +269,7 @@ spec:
               description: Retention sets how many backups should be kept after a forget and prune
               properties:
                 hostnames:
-                  description: Hosntames is a filter on what hostnames the policy should be applied
+                  description: Hostnames is a filter on what hostnames the policy should be applied
                   items:
                     type: string
                   type: array

--- a/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_schedules.yaml
+++ b/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_schedules.yaml
@@ -1284,7 +1284,7 @@ spec:
                   description: Retention sets how many backups should be kept after a forget and prune
                   properties:
                     hostnames:
-                      description: Hosntames is a filter on what hostnames the policy should be applied
+                      description: Hostnames is a filter on what hostnames the policy should be applied
                       items:
                         type: string
                       type: array

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -7,7 +7,7 @@ install_bats:
 
 run_bats: export KUBECONFIG = $(KIND_KUBECONFIG)
 run_bats:
-	@mkdir debug || true
+	@mkdir -p debug || true
 	@node_modules/.bin/bats .
 
 clean:


### PR DESCRIPTION
* Fixing a typo in the documentation
* Reduce a complaint in the `Makefile` of the e2e-test if the folder `debug` already exists when `mkdir` tries to create it:
  ```
  mkdir: cannot create directory ‘debug’: File exists
  ```