### PR TITLE
Self-documenting Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ You'll need:
 - make
 
 These are the most common make targets: `build`, `test`, `docker-build`, `run`.
+Run `make help` to get an overview over the relevant targets and their intentions.
 
 ## Generate kubernetes code
 

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -2,9 +2,10 @@
 # Set Shell to bash, otherwise some targets fail with dash/zsh etc.
 SHELL := /bin/bash
 
-install_bats:
-	@npm install
+.PHONY: install_bats
+install_bats: node_modules/.bin/bats
 
+.PHONY: run_bats
 run_bats: export KUBECONFIG = $(KIND_KUBECONFIG)
 run_bats:
 	@mkdir -p debug || true
@@ -12,3 +13,8 @@ run_bats:
 
 clean:
 	rm -r debug node_modules || true
+
+node_modules/.bin/bats: node_modules
+
+node_modules:
+	@npm install


### PR DESCRIPTION
This PR applies a neat trick as described in https://www.freecodecamp.org/news/self-documenting-makefile/.
A new `make` target called `help` is introduced that lists all documented targets and their documentation comment.

The syntax is simple:

```Makefile
# Makefile

target: ## I'm the documentation for the target
    @echo I'm the target code
```