### PR TITLE
Fix 'tar: Error opening File' when `make intergration_test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,8 @@ $(TESTBIN_DIR):
 
 # See https://storage.googleapis.com/kubebuilder-tools/ for list of supported K8s versions
 # No, there's no 1.18 support, so we're going for 1.19
-integration_test: export ENVTEST_K8S_VERSION = 1.19.2 ## Run integration tests with envtest
-integration_test: generate fmt vet $(TESTBIN_DIR)
+integration_test: export ENVTEST_K8S_VERSION = 1.19.2
+integration_test: generate fmt vet $(TESTBIN_DIR) ## Run integration tests with envtest
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/hack/setup-envtest.sh
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test -tags=integration -v ./... -coverprofile cover.out
 


### PR DESCRIPTION
    tar: Error opening archive: Failed to open '/tmp/kubebuilder-tools-1.19.2 -darwin-amd64.tar.gz'

This error occured because the documenting comment was on the wrong line, leading to '1.19.2 ' (with whitespace) being exported as `ENVTEST_K8S_VERSION`, instead of '1.19.2'.