### PR TITLE
Disable LEADER_ELECTION by default for `make run run_kind`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ KIND_REGISTRY_PORT ?= 5000
 
 SETUP_E2E_TEST := testbin/.setup_e2e_test
 
+ENABLE_LEADER_ELECTION ?= false
+
 # Image URL to use all building/pushing image targets
 DOCKER_IMG ?= docker.io/vshn/k8up:$(IMG_TAG)
 QUAY_IMG ?= quay.io/vshn/k8up:$(IMG_TAG)
@@ -78,6 +80,7 @@ build: generate fmt vet ## Build manager binary
 dist: generate fmt vet ## Generates a release
 	goreleaser release --snapshot --rm-dist --skip-sign
 
+run: export BACKUP_ENABLE_LEADER_ELECTION = $(ENABLE_LEADER_ELECTION)
 run: fmt vet ## Run against the configured Kubernetes cluster in ~/.kube/config
 	go run ./main.go
 
@@ -138,6 +141,7 @@ e2e_test: install_bats $(SETUP_E2E_TEST) docker-build ## Runs the e2e test suite
 	$(MAKE) -C e2e run_bats -e KUBECONFIG=../$(KIND_KUBECONFIG)
 
 run_kind: export KUBECONFIG = $(KIND_KUBECONFIG)
+run_kind: export BACKUP_ENABLE_LEADER_ELECTION = $(ENABLE_LEADER_ELECTION)
 run_kind: $(SETUP_E2E_TEST) ## Runs the operator in kind
 	go run ./main.go
 


### PR DESCRIPTION
Without further configuration, k8up expects a k8s cluster to have a leader election namespace.

Just executing `make run` oder `make run_kind` therefore leads to the following error message:

    0000-00-00T00:00:00.000+0100	ERROR	setup	unable to start K8up operator	{"error": "unable to find leader election namespace: not running in-cluster, please specify LeaderElectionNamespace"}

This PR adjusts the Makefile in a way such that when invoking the mentioned make targets no leader election namespace is required.