### PR TITLE
Fix Null Pointer Dereference

### DIFF
--- a/handler/schedule.go
+++ b/handler/schedule.go
@@ -89,7 +89,7 @@ func (s *ScheduleHandler) createJobList() scheduler.JobList {
 		})
 	}
 	if s.schedule.Spec.Check != nil {
-		s.schedule.Spec.Check.CheckSpec.Resources = s.mergeResourcesWithDefaults(s.schedule.Spec.Archive.Resources)
+		s.schedule.Spec.Check.CheckSpec.Resources = s.mergeResourcesWithDefaults(s.schedule.Spec.Check.Resources)
 		jobList.Jobs = append(jobList.Jobs, scheduler.Job{
 			Type:     scheduler.CheckType,
 			Schedule: s.schedule.Spec.Check.Schedule,


### PR DESCRIPTION
There is an error in the code which leads to a null pointer dereference panic during runtime.
`s.schedule.Spec.Archive` is referenced, whereas `s.schedule.Spec.Check` is tested for non-nullness. This seems wrong and will be rectified in this PR.