### PR TITLE
Fix AccountKeySecretRef in Azure backend spec

### DIFF
--- a/api/v1alpha1/backend.go
+++ b/api/v1alpha1/backend.go
@@ -205,13 +205,13 @@ func (g *GCSSpec) EnvVars(vars map[string]*corev1.EnvVarSource) map[string]*core
 type AzureSpec struct {
 	Container            string                    `json:"container,omitempty"`
 	AccountNameSecretRef *corev1.SecretKeySelector `json:"accountNameSecretRef,omitempty"`
-	AccountKeySecreftRef *corev1.SecretKeySelector `json:"accountKeySecreftRef,omitempty"`
+	AccountKeySecretRef  *corev1.SecretKeySelector `json:"accountKeySecretRef,omitempty"`
 }
 
 func (a *AzureSpec) EnvVars(vars map[string]*corev1.EnvVarSource) map[string]*corev1.EnvVarSource {
-	if a.AccountKeySecreftRef != nil {
+	if a.AccountKeySecretRef != nil {
 		vars["AZURE_ACCOUNT_KEY"] = &corev1.EnvVarSource{
-			SecretKeyRef: a.AccountKeySecreftRef,
+			SecretKeyRef: a.AccountKeySecretRef,
 		}
 	}
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -120,8 +120,8 @@ func (in *AzureSpec) DeepCopyInto(out *AzureSpec) {
 		*out = new(v1.SecretKeySelector)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.AccountKeySecreftRef != nil {
-		in, out := &in.AccountKeySecreftRef, &out.AccountKeySecreftRef
+	if in.AccountKeySecretRef != nil {
+		in, out := &in.AccountKeySecretRef, &out.AccountKeySecretRef
 		*out = new(v1.SecretKeySelector)
 		(*in).DeepCopyInto(*out)
 	}

--- a/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_archives.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_archives.yaml
@@ -37,7 +37,7 @@ spec:
                 properties:
                   azure:
                     properties:
-                      accountKeySecreftRef:
+                      accountKeySecretRef:
                         description: SecretKeySelector selects a key of a Secret.
                         properties:
                           key:

--- a/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_backups.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_backups.yaml
@@ -37,7 +37,7 @@ spec:
                 properties:
                   azure:
                     properties:
-                      accountKeySecreftRef:
+                      accountKeySecretRef:
                         description: SecretKeySelector selects a key of a Secret.
                         properties:
                           key:

--- a/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_checks.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_checks.yaml
@@ -36,7 +36,7 @@ spec:
                 properties:
                   azure:
                     properties:
-                      accountKeySecreftRef:
+                      accountKeySecretRef:
                         description: SecretKeySelector selects a key of a Secret.
                         properties:
                           key:

--- a/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_prunes.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_prunes.yaml
@@ -36,7 +36,7 @@ spec:
                 properties:
                   azure:
                     properties:
-                      accountKeySecreftRef:
+                      accountKeySecretRef:
                         description: SecretKeySelector selects a key of a Secret.
                         properties:
                           key:

--- a/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_restores.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_restores.yaml
@@ -37,7 +37,7 @@ spec:
                 properties:
                   azure:
                     properties:
-                      accountKeySecreftRef:
+                      accountKeySecretRef:
                         description: SecretKeySelector selects a key of a Secret.
                         properties:
                           key:

--- a/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_schedules.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_schedules.yaml
@@ -40,7 +40,7 @@ spec:
                     properties:
                       azure:
                         properties:
-                          accountKeySecreftRef:
+                          accountKeySecretRef:
                             description: SecretKeySelector selects a key of a Secret.
                             properties:
                               key:
@@ -339,7 +339,7 @@ spec:
                 properties:
                   azure:
                     properties:
-                      accountKeySecreftRef:
+                      accountKeySecretRef:
                         description: SecretKeySelector selects a key of a Secret.
                         properties:
                           key:
@@ -552,7 +552,7 @@ spec:
                     properties:
                       azure:
                         properties:
-                          accountKeySecreftRef:
+                          accountKeySecretRef:
                             description: SecretKeySelector selects a key of a Secret.
                             properties:
                               key:
@@ -805,7 +805,7 @@ spec:
                     properties:
                       azure:
                         properties:
-                          accountKeySecreftRef:
+                          accountKeySecretRef:
                             description: SecretKeySelector selects a key of a Secret.
                             properties:
                               key:
@@ -1049,7 +1049,7 @@ spec:
                     properties:
                       azure:
                         properties:
-                          accountKeySecreftRef:
+                          accountKeySecretRef:
                             description: SecretKeySelector selects a key of a Secret.
                             properties:
                               key:
@@ -1343,7 +1343,7 @@ spec:
                     properties:
                       azure:
                         properties:
-                          accountKeySecreftRef:
+                          accountKeySecretRef:
                             description: SecretKeySelector selects a key of a Secret.
                             properties:
                               key:

--- a/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_archives.yaml
+++ b/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_archives.yaml
@@ -37,7 +37,7 @@ spec:
               properties:
                 azure:
                   properties:
-                    accountKeySecreftRef:
+                    accountKeySecretRef:
                       description: SecretKeySelector selects a key of a Secret.
                       properties:
                         key:

--- a/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_backups.yaml
+++ b/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_backups.yaml
@@ -37,7 +37,7 @@ spec:
               properties:
                 azure:
                   properties:
-                    accountKeySecreftRef:
+                    accountKeySecretRef:
                       description: SecretKeySelector selects a key of a Secret.
                       properties:
                         key:

--- a/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_checks.yaml
+++ b/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_checks.yaml
@@ -36,7 +36,7 @@ spec:
               properties:
                 azure:
                   properties:
-                    accountKeySecreftRef:
+                    accountKeySecretRef:
                       description: SecretKeySelector selects a key of a Secret.
                       properties:
                         key:

--- a/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_prunes.yaml
+++ b/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_prunes.yaml
@@ -36,7 +36,7 @@ spec:
               properties:
                 azure:
                   properties:
-                    accountKeySecreftRef:
+                    accountKeySecretRef:
                       description: SecretKeySelector selects a key of a Secret.
                       properties:
                         key:

--- a/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_restores.yaml
+++ b/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_restores.yaml
@@ -37,7 +37,7 @@ spec:
               properties:
                 azure:
                   properties:
-                    accountKeySecreftRef:
+                    accountKeySecretRef:
                       description: SecretKeySelector selects a key of a Secret.
                       properties:
                         key:

--- a/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_schedules.yaml
+++ b/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_schedules.yaml
@@ -40,7 +40,7 @@ spec:
                   properties:
                     azure:
                       properties:
-                        accountKeySecreftRef:
+                        accountKeySecretRef:
                           description: SecretKeySelector selects a key of a Secret.
                           properties:
                             key:
@@ -339,7 +339,7 @@ spec:
               properties:
                 azure:
                   properties:
-                    accountKeySecreftRef:
+                    accountKeySecretRef:
                       description: SecretKeySelector selects a key of a Secret.
                       properties:
                         key:
@@ -552,7 +552,7 @@ spec:
                   properties:
                     azure:
                       properties:
-                        accountKeySecreftRef:
+                        accountKeySecretRef:
                           description: SecretKeySelector selects a key of a Secret.
                           properties:
                             key:
@@ -805,7 +805,7 @@ spec:
                   properties:
                     azure:
                       properties:
-                        accountKeySecreftRef:
+                        accountKeySecretRef:
                           description: SecretKeySelector selects a key of a Secret.
                           properties:
                             key:
@@ -1049,7 +1049,7 @@ spec:
                   properties:
                     azure:
                       properties:
-                        accountKeySecreftRef:
+                        accountKeySecretRef:
                           description: SecretKeySelector selects a key of a Secret.
                           properties:
                             key:
@@ -1343,7 +1343,7 @@ spec:
                   properties:
                     azure:
                       properties:
-                        accountKeySecreftRef:
+                        accountKeySecretRef:
                           description: SecretKeySelector selects a key of a Secret.
                           properties:
                             key:


### PR DESCRIPTION
The `AccountNameSecretRef` and `AccountKeySecretRef` are new unreleased properties, so we don't need to worry about backwards incompatible changes.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
