### PR TITLE
Replace internal schedules when reconciling Schedule CRs

### DIFF
--- a/api/v1alpha1/job_types.go
+++ b/api/v1alpha1/job_types.go
@@ -1,7 +1,9 @@
 package v1alpha1
 
-// JobType defines what job type this is.
-type JobType string
+type (
+	// JobType defines what job type this is.
+	JobType string
+)
 
 const (
 	BackupType   JobType = "backup"

--- a/handler/schedule.go
+++ b/handler/schedule.go
@@ -55,7 +55,7 @@ func (s *ScheduleHandler) Handle() error {
 	jobList := s.createJobList()
 
 	scheduler.GetScheduler().RemoveSchedules(namespacedName)
-	err = scheduler.GetScheduler().AddSchedules(jobList)
+	err = scheduler.GetScheduler().SyncSchedules(jobList)
 	if err != nil {
 		return fmt.Errorf("cannot add to cron: %w", err)
 	}
@@ -81,40 +81,45 @@ func (s *ScheduleHandler) createJobList() scheduler.JobList {
 
 	if s.schedule.Spec.Archive != nil {
 		s.schedule.Spec.Archive.ArchiveSpec.Resources = s.mergeResourcesWithDefaults(s.schedule.Spec.Archive.Resources)
+		jobType := k8upv1alpha1.ArchiveType
 		jobList.Jobs = append(jobList.Jobs, scheduler.Job{
-			Type:     scheduler.ArchiveType,
-			Schedule: s.getEffectiveSchedule(k8upv1alpha1.ArchiveType, s.schedule.Spec.Archive.Schedule),
+			JobType:  jobType,
+			Schedule: s.getEffectiveSchedule(jobType, s.schedule.Spec.Archive.Schedule),
 			Object:   s.schedule.Spec.Archive.ArchiveSpec,
 		})
 	}
 	if s.schedule.Spec.Backup != nil {
 		s.schedule.Spec.Backup.BackupSpec.Resources = s.mergeResourcesWithDefaults(s.schedule.Spec.Backup.Resources)
+		jobType := k8upv1alpha1.BackupType
 		jobList.Jobs = append(jobList.Jobs, scheduler.Job{
-			Type:     scheduler.BackupType,
+			JobType:  jobType,
 			Schedule: s.getEffectiveSchedule(k8upv1alpha1.BackupType, s.schedule.Spec.Backup.Schedule),
 			Object:   s.schedule.Spec.Backup.BackupSpec,
 		})
 	}
 	if s.schedule.Spec.Check != nil {
 		s.schedule.Spec.Check.CheckSpec.Resources = s.mergeResourcesWithDefaults(s.schedule.Spec.Check.Resources)
+		jobType := k8upv1alpha1.CheckType
 		jobList.Jobs = append(jobList.Jobs, scheduler.Job{
-			Type:     scheduler.CheckType,
+			JobType:  jobType,
 			Schedule: s.getEffectiveSchedule(k8upv1alpha1.CheckType, s.schedule.Spec.Check.Schedule),
 			Object:   s.schedule.Spec.Check.CheckSpec,
 		})
 	}
 	if s.schedule.Spec.Restore != nil {
 		s.schedule.Spec.Restore.RestoreSpec.Resources = s.mergeResourcesWithDefaults(s.schedule.Spec.Restore.Resources)
+		jobType := k8upv1alpha1.RestoreType
 		jobList.Jobs = append(jobList.Jobs, scheduler.Job{
-			Type:     scheduler.RestoreType,
+			JobType:  jobType,
 			Schedule: s.getEffectiveSchedule(k8upv1alpha1.RestoreType, s.schedule.Spec.Restore.Schedule),
 			Object:   s.schedule.Spec.Restore.RestoreSpec,
 		})
 	}
 	if s.schedule.Spec.Prune != nil {
 		s.schedule.Spec.Prune.PruneSpec.Resources = s.mergeResourcesWithDefaults(s.schedule.Spec.Prune.Resources)
+		jobType := k8upv1alpha1.PruneType
 		jobList.Jobs = append(jobList.Jobs, scheduler.Job{
-			Type:     scheduler.PruneType,
+			JobType:  jobType,
 			Schedule: s.getEffectiveSchedule(k8upv1alpha1.PruneType, s.schedule.Spec.Prune.Schedule),
 			Object:   s.schedule.Spec.Prune.PruneSpec,
 		})

--- a/handler/schedule.go
+++ b/handler/schedule.go
@@ -2,16 +2,18 @@ package handler
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/imdario/mergo"
-	k8upv1alpha1 "github.com/vshn/k8up/api/v1alpha1"
-	"github.com/vshn/k8up/cfg"
-	"github.com/vshn/k8up/job"
-	"github.com/vshn/k8up/scheduler"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"strings"
+
+	k8upv1alpha1 "github.com/vshn/k8up/api/v1alpha1"
+	"github.com/vshn/k8up/cfg"
+	"github.com/vshn/k8up/job"
+	"github.com/vshn/k8up/scheduler"
 )
 
 const (
@@ -52,6 +54,7 @@ func (s *ScheduleHandler) Handle() error {
 
 	jobList := s.createJobList()
 
+	scheduler.GetScheduler().RemoveSchedules(namespacedName)
 	err = scheduler.GetScheduler().AddSchedules(jobList)
 	if err != nil {
 		return fmt.Errorf("cannot add to cron: %w", err)

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -1,0 +1,109 @@
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	k8upv1alpha1 "github.com/vshn/k8up/api/v1alpha1"
+	"github.com/vshn/k8up/job"
+)
+
+func TestScheduler_SyncSchedules(t *testing.T) {
+	ns := "test-namespace"
+	obj := &k8upv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      "my-backup",
+		},
+	}
+	nsName := types.NamespacedName{
+		Namespace: obj.Namespace,
+		Name:      obj.Name,
+	}
+	tests := map[string]struct {
+		expectErr            bool
+		existingJobs         []Job
+		expectedScheduleRefs []scheduleRef
+		newJobs              []Job
+	}{
+		"GivenExistingSchedule_WhenReplacingScheduleWithExistingJobType_ThenReplaceTheSchedule": {
+			existingJobs: []Job{
+				{JobType: k8upv1alpha1.PruneType, Schedule: "1 * * * *"},
+			},
+			newJobs: []Job{
+				{JobType: k8upv1alpha1.PruneType, Schedule: "* * * * *"},
+			},
+			expectedScheduleRefs: []scheduleRef{
+				{JobType: k8upv1alpha1.PruneType, Schedule: "* * * * *"},
+			},
+		},
+		"GivenInexistentSchedule_WhenAddingWithNewSchedule_ThenAddSchedule": {
+			newJobs: []Job{
+				{JobType: k8upv1alpha1.PruneType, Schedule: "* * * * *"},
+			},
+			expectedScheduleRefs: []scheduleRef{
+				{JobType: k8upv1alpha1.PruneType, Schedule: "* * * * *"},
+			},
+		},
+		"GivenExistingSchedule_WhenReplacingUnmatchedSchedule_ThenAddSchedule": {
+			existingJobs: []Job{
+				{JobType: k8upv1alpha1.PruneType, Schedule: "1 * * * *"},
+			},
+			newJobs: []Job{
+				{JobType: k8upv1alpha1.PruneType, Schedule: "1 * * * *"},
+				{JobType: k8upv1alpha1.ArchiveType, Schedule: "* * * * *"},
+			},
+			expectedScheduleRefs: []scheduleRef{
+				{JobType: k8upv1alpha1.PruneType, Schedule: "1 * * * *"},
+				{JobType: k8upv1alpha1.ArchiveType, Schedule: "* * * * *"},
+			},
+		},
+		"GivenExistingSchedule_WhenSyncingSchedules_ThenRemoveInexistentSchedule": {
+			existingJobs: []Job{
+				{JobType: k8upv1alpha1.PruneType, Schedule: "1 * * * *"},
+				{JobType: k8upv1alpha1.ArchiveType, Schedule: "* * * * *"},
+			},
+			newJobs: []Job{
+				{JobType: k8upv1alpha1.PruneType, Schedule: "1 * * * *"},
+			},
+			expectedScheduleRefs: []scheduleRef{
+				{JobType: k8upv1alpha1.PruneType, Schedule: "1 * * * *"},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			s := newScheduler()
+			jobList := JobList{
+				Jobs: tt.newJobs,
+				Config: job.Config{
+					Log: zap.New(zap.UseDevMode(true)),
+					Obj: obj,
+				},
+			}
+			for _, jb := range tt.existingJobs {
+				require.NoError(t, s.addSchedule(jb, nsName, func() {
+
+				}))
+			}
+			err := s.SyncSchedules(jobList)
+			if tt.expectErr {
+				assert.Error(t, err)
+				return
+			} else {
+				assert.NoError(t, err)
+			}
+			scheduleRefs := s.registeredSchedules[types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}.String()]
+			require.Len(t, scheduleRefs, len(tt.expectedScheduleRefs))
+			for i, ref := range tt.expectedScheduleRefs {
+				assert.Equal(t, ref.Schedule, scheduleRefs[i].Schedule)
+				assert.Equal(t, ref.JobType, scheduleRefs[i].JobType)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #237

Neither the Cron library nor our internal wrapping have a method to Update existing schedules, thus we recreate the schedules when reconciling Schedule CRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
