### PR TITLE
Skip tagging and publishing of floating tags in prereleases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,23 +16,19 @@ snapshot:
   name_template: "{{ .Tag }}-snapshot"
 
 dockers:
-# For pre releases, updating `latest` and the floating tags of the major
-# version does not make sense. So only the image for the exact version should
-# be pushed.
-# For the lack of a less verbose solution, go templating is used to set the
-# image tags to the major version or latest for normal releases. For pre
-# releases, all image tags are set to the exact version. This will result in
-# having the same image tag tree times in the list. This is fine to do as the
-# image will be built only once and tagging is a cheap operation.
+
 - image_templates:
   - "docker.io/vshn/k8up:v{{ .Version }}"
   - "quay.io/vshn/k8up:v{{ .Version }}"
 
-  - "docker.io/vshn/k8up:{{ if .Prerelease }}v{{ .Version }}{{ else }}v{{ .Major }}{{ end }}"
-  - "quay.io/vshn/k8up:{{ if .Prerelease }}v{{ .Version }}{{ else }}v{{ .Major }}{{ end }}"
+  # For prereleases, updating `latest` and the floating tags of the major
+  # version does not make sense. Only the image for the exact version should
+  # be pushed.
+  - "{{ if not .Prerelease }}docker.io/vshn/k8up:v{{ .Major }}{{ end }}"
+  - "{{ if not .Prerelease }}quay.io/vshn/k8up:v{{ .Major }}{{ end }}"
 
-  - "docker.io/vshn/k8up:{{ if .Prerelease }}v{{ .Version }}{{ else }}latest{{ end }}"
-  - "quay.io/vshn/k8up:{{ if .Prerelease }}v{{ .Version }}{{ else }}latest{{ end }}"
+  - "{{ if not .Prerelease }}docker.io/vshn/k8up:latest{{ end }}"
+  - "{{ if not .Prerelease }}quay.io/vshn/k8up:latest{{ end }}"
 
 changelog:
   sort: asc
@@ -45,7 +41,6 @@ changelog:
 
 release:
   prerelease: auto
-
   github:
     owner: vshn
     name: k8up


### PR DESCRIPTION
After https://github.com/goreleaser/goreleaser/issues/1969 is now fixed, we can optimize the image_template setting which doesn't list duplicate image tags in the Prereleases anymore.

BUT we have to wait until Goreleaser and Goreleaser Action are bumped with the latest release

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
