### PR TITLE
Replace Goreleaser changelog generator with PR-based generator

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,7 @@
+## Summary
+
+
+
 <!--
 Thank you for your pull request. Please provide a description above and
 review the checklist below.
@@ -9,6 +13,9 @@ Remove items that do not apply. For completed items, change [ ] to [x].
 -->
 
 - [ ] Keep pull requests small so they can be easily reviewed.
+- [ ] Categorize the PR by setting a good title and adding one of the labels:
+      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
+      as they show up in the changelog
 - [ ] Update the documentation.
 - [ ] Update tests.
 - [ ] Link this PR to related issues.

--- a/.github/changelog-configuration.json
+++ b/.github/changelog-configuration.json
@@ -1,0 +1,29 @@
+{
+    "pr_template": "- ${{TITLE}} (#${{NUMBER}})",
+    "categories": [
+        {
+            "title": "## 🚀 Features",
+            "labels": ["enhancement", "feature"]
+        },
+        {
+            "title": "## 🛠️ Minor Changes",
+            "labels": ["change"]
+        },
+        {
+            "title": "## 🔎 Breaking Changes",
+            "labels": ["breaking"]
+        },
+        {
+            "title": "## 🐛 Fixes",
+            "labels": ["bug", "fix"]
+        },
+        {
+            "title": "## 📄 Documentation",
+            "labels": ["documentation"]
+        },
+        {
+            "title": "## 🔗 Dependency Updates",
+            "labels": ["dependency"]
+        }
+    ]
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,21 @@ jobs:
       run: docker login -u "${{ secrets.QUAY_IO_USERNAME }}" -p "${{ secrets.QUAY_IO_PASSWORD }}" quay.io
     - name: Generate artifacts
       run: make crd
+    - name: Build changelog from PRs with labels
+      id: build_changelog
+      uses: mikepenz/release-changelog-builder-action@v1.2.3
+      with:
+        configuration: ".github/changelog-configuration.json"
+        # Prereleases still get a changelog, but the next full release gets a diff since the last full release,
+        # combining possible changelogs of all previous prereleases inbetween.
+        ignorePreReleases: "true"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Make release notes
+      run: echo "${{steps.build_changelog.outputs.changelog}}" > .github/release-notes.md
     - name: Publish releases
       uses: goreleaser/goreleaser-action@v2
       with:
-        args: release
+        args: release --release-notes .github/release-notes.md
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ cmd/restic/restic
 
 bin/
 dist/
+.github/release-notes.md
 k8up-crd*.yaml
 k8up
 testbin/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,15 +30,6 @@ dockers:
   - "{{ if not .Prerelease }}docker.io/vshn/k8up:latest{{ end }}"
   - "{{ if not .Prerelease }}quay.io/vshn/k8up:latest{{ end }}"
 
-changelog:
-  sort: asc
-  filters:
-    exclude:
-    - '^(D|d)oc(s|umentation):'
-    - '^(T|t)ests?:'
-    - '^(R|r)efactor:'
-    - '^Merge pull request'
-
 release:
   prerelease: auto
   github:

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "labels": ["dependency"]
 }


### PR DESCRIPTION
## Summary

Goreleaser builds changelog from commits, which are too detailed and uncategorized for human readers. 
The alternative changelog generator uses GitHub API to build a changelog from PRs, categorized by labels.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
