### PR TITLE
Ignore existing prebackup deployments

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,18 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - backup.appuio.ch
   resources:
   - archives

--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -27,6 +27,7 @@ type BackupReconciler struct {
 // +kubebuilder:rbac:groups=backup.appuio.ch,resources=backups/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=backup.appuio.ch,resources=prebackuppods,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=backup.appuio.ch,resources=prebackuppods/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs="*"
 // +kubebuilder:rbac:groups=core,resources=pods/exec,verbs="*"

--- a/prebackup/prebackup.go
+++ b/prebackup/prebackup.go
@@ -208,7 +208,7 @@ func (p *PreBackup) waitForReady(watcher watch.Interface) error {
 				return nil
 			}
 
-			p.Log.Info("waiting for command pod to get ready", "name", deployment.Name, "namespace", deployment.Namespace)
+			p.Log.Info("waiting for command pod to get ready", "deployment", fmt.Sprintf("%s/%s", deployment.Namespace, deployment.Name))
 
 		case watch.Error:
 
@@ -219,8 +219,10 @@ func (p *PreBackup) waitForReady(watcher watch.Interface) error {
 			}
 			return fmt.Errorf("there was an unknown error while starting pre backup pod '%v/%v'", deployment.Namespace, deployment.Name)
 
+		case watch.Added:
+			p.Log.V(1).Info("ignoring event", "deployment", fmt.Sprintf("%s/%s", deployment.Namespace, deployment.Name), "event type", event.Type)
 		default:
-			p.Log.Info("unexpected event during deployment watch ", "name", deployment.Name, "event type", event.Type, "namespace", deployment.Namespace)
+			p.Log.Info("unexpected event during deployment watch ", "deployment", fmt.Sprintf("%s/%s", deployment.Namespace, deployment.Name), "event type", event.Type)
 		}
 	}
 

--- a/prebackup/prebackup.go
+++ b/prebackup/prebackup.go
@@ -137,7 +137,7 @@ func (p *PreBackup) startAndWaitForReady(deployments []appsv1.Deployment) error 
 		deployment := deployment
 
 		err := p.Client.Create(p.CTX, &deployment)
-		if err != nil {
+		if err != nil && !errors.IsAlreadyExists(err) {
 			err := fmt.Errorf("error creating pre backup pod '%v/%v': %w", namespace, name, err)
 			p.SetConditionFalse(ConditionPreBackupPodsReady, err.Error())
 			return err


### PR DESCRIPTION
## Summary

This should ignore AlreadyExists errors when creating prebackup deployments.

Fixes #246 

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Link this PR to related issues.
