### PR TITLE
Show link to changelog in the docs

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,4 +1,7 @@
 * xref:index.adoc[Home]
+ifeval::['{page-origin-reftype}' == 'tag']
+* https://github.com/vshn/k8up/releases/tag/{page-origin-refname}[Changelog,window=_blank]
+endif::[]
 
 .Tutorials
 include::partial$nav-tutorials.adoc[]


### PR DESCRIPTION
## Summary

* This will display a link in the navigation pointing to GitHub release, but only when the Antora component was built from a tag in the playbook (not master for example), see https://docs.antora.org/antora/2.3/page/intrinsic-attributes/#page-attributes

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
