### PR TITLE
Separate e2e tests and KIND from main Makefile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Run e2e tests
-      run: make crd e2e_test -e CRD_SPEC_VERSION=${{ matrix.crd-spec-version }} -e KIND_NODE_VERSION=${{ matrix.kind-node-version }} -e KIND_KUBECTL_ARGS=--validate=false
+      run: make crd e2e-test -e CRD_SPEC_VERSION=${{ matrix.crd-spec-version }} -e KIND_NODE_VERSION=${{ matrix.kind-node-version }} -e KIND_KUBECTL_ARGS=--validate=false
     - name: Show e2e debug logs
       run: cat e2e/debug/detik/*
   image:

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,18 @@
 # Set Shell to bash, otherwise some targets fail with dash/zsh etc.
 SHELL := /bin/bash
 
-# Current Operator version
-VERSION ?= $(shell date +%Y-%m-%d_%H-%M-%S)
-# Default bundle image tag
-BUNDLE_IMG ?= controller-bundle:$(VERSION)
+# Disable built-in rules
+MAKEFLAGS += --no-builtin-rules
+MAKEFLAGS += --no-builtin-variables
+.SUFFIXES:
+.SECONDARY:
+
+PROJECT_ROOT_DIR = .
+include Makefile.vars.mk
+
+e2e_make := $(MAKE) -C e2e -e 'VERSION=$(VERSION)'
+go_build ?= CGO_ENABLED=0 go build -o $(BIN_FILENAME) main.go
+
 # Options for 'bundle-build'
 ifneq ($(origin CHANNELS), undefined)
 BUNDLE_CHANNELS := --channels=$(CHANNELS)
@@ -14,37 +22,6 @@ BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
-IMG_TAG ?= latest
-
-BIN_FILENAME ?= k8up
-
-CRD_SPEC_VERSION ?= v1
-
-CRD_FILE ?= k8up-crd.yaml
-CRD_FILE_LEGACY ?= k8up-crd-legacy.yaml
-CRD_ROOT_DIR ?= config/crd/apiextensions.k8s.io
-
-TESTBIN_DIR ?= ./testbin/bin
-KIND_BIN ?= $(TESTBIN_DIR)/kind
-KIND_VERSION ?= 0.9.0
-KIND_NODE_VERSION ?= v1.18.8
-KIND_KUBECONFIG ?= ./testbin/kind-kubeconfig-$(KIND_NODE_VERSION)
-KIND_CLUSTER ?= k8up-$(KIND_NODE_VERSION)
-KIND_KUBECTL_ARGS ?= --validate=true
-
-SETUP_KIND := testbin/.kind_setup_complete
-E2E_TAG ?= e2e_$(VERSION)
-E2E_REPO ?= local.dev/k8up/e2e
-
-ENABLE_LEADER_ELECTION ?= false
-
-# Image URL to use all building/pushing image targets
-DOCKER_IMG ?= docker.io/vshn/k8up:$(IMG_TAG)
-QUAY_IMG ?= quay.io/vshn/k8up:$(IMG_TAG)
-E2E_IMG := $(E2E_REPO):$(E2E_TAG)
-
-build_cmd ?= CGO_ENABLED=0 go build -o $(BIN_FILENAME) main.go
-
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -52,74 +29,72 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-KUSTOMIZE ?= go run sigs.k8s.io/kustomize/kustomize/v3
-KUSTOMIZE_BUILD_CRD ?= $(KUSTOMIZE) build $(CRD_ROOT_DIR)/$(CRD_SPEC_VERSION)
-
-all: build ## Invokes the build target
-
-test: fmt vet ## Run tests
-	go test ./... -coverprofile cover.out
-
 # Run tests (see https://sdk.operatorframework.io/docs/building-operators/golang/references/envtest-setup)
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 
-$(TESTBIN_DIR):
-	mkdir -p $(TESTBIN_DIR)
+all: build ## Invokes the build target
+
+.PHONY: test
+test: fmt vet ## Run tests
+	go test ./... -coverprofile cover.out
 
 # See https://storage.googleapis.com/kubebuilder-tools/ for list of supported K8s versions
 # No, there's no 1.18 support, so we're going for 1.19
-integration_test: export ENVTEST_K8S_VERSION = 1.19.2
-integration_test: generate fmt vet $(TESTBIN_DIR) ## Run integration tests with envtest
+integration-test: export ENVTEST_K8S_VERSION = 1.19.2
+integration-test: generate fmt vet $(testbin_created) ## Run integration tests with envtest
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/hack/setup-envtest.sh
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test -tags=integration -v ./... -coverprofile cover.out
 
-build: generate fmt vet ## Build manager binary
-	$(build_cmd)
+.PHONY: build
+build: generate fmt vet $(BIN_FILENAME) ## Build manager binary
 
-dist: generate fmt vet ## Generates a release
-	goreleaser release --snapshot --rm-dist --skip-sign
-
+.PHONY: run
 run: export BACKUP_ENABLE_LEADER_ELECTION = $(ENABLE_LEADER_ELECTION)
 run: fmt vet ## Run against the configured Kubernetes cluster in ~/.kube/config
 	go run ./main.go
 
+.PHONY: install
 install: generate ## Install CRDs into a cluster
-	$(KUSTOMIZE) build $(CRD_ROOT_DIR)/v1 | kubectl apply -f -
+	$(KUSTOMIZE) build $(CRD_ROOT_DIR)/$(CRD_SPEC_VERSION) | kubectl apply $(KIND_KUBECTL_ARGS) -f -
 
+.PHONY: uninstall
 uninstall: generate ## Uninstall CRDs from a cluster
-	$(KUSTOMIZE) build $(CRD_ROOT_DIR)/v1 | kubectl delete -f -
+	$(KUSTOMIZE) build $(CRD_ROOT_DIR)/$(CRD_SPEC_VERSION) | kubectl delete -f -
 
+.PHONY: deploy
 deploy: generate ## Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
+.PHONY: generate
 generate: ## Generate manifests e.g. CRD, RBAC etc.
 	@CRD_ROOT_DIR="$(CRD_ROOT_DIR)" go generate -tags=generate generate.go
 	@rm config/*.yaml
 
+.PHONY: crd
 crd: generate ## Generate CRD to file
 	$(KUSTOMIZE) build $(CRD_ROOT_DIR)/v1 > $(CRD_FILE)
 	$(KUSTOMIZE) build $(CRD_ROOT_DIR)/v1beta1 > $(CRD_FILE_LEGACY)
 
+.PHONY: fmt
 fmt: ## Run go fmt against code
 	go fmt ./...
 
+.PHONY: vet
 vet: ## Run go vet against code
 	go vet ./...
 
+.PHONY: lint
 lint: fmt vet ## Invokes the fmt and vet targets
 	@echo 'Check for uncommitted changes ...'
 	git diff --exit-code
 
-# Build the binary without running generators
-.PHONY: $(BIN_FILENAME)
-$(BIN_FILENAME):
-	$(build_cmd)
-
+.PHONY: docker-build
 docker-build: export GOOS = linux
 docker-build: $(BIN_FILENAME) ## Build the docker image
 	docker build . -t $(DOCKER_IMG) -t $(QUAY_IMG) -t $(E2E_IMG)
 
+.PHONY: docker-push
 docker-push: ## Push the docker image
 	docker push $(DOCKER_IMG)
 	docker push $(QUAY_IMG)
@@ -132,7 +107,7 @@ bundle: generate ## Generate bundle manifests and metadata, then validate genera
 	operator-sdk bundle validate ./bundle
 
 clean: export KUBECONFIG = $(KIND_KUBECONFIG)
-clean: clean_e2e clean_kind ## Cleans up the generated resources
+clean: e2e-clean kind-clean ## Cleans up the generated resources
 	rm -r testbin/ dist/ bin/ cover.out $(BIN_FILENAME) || true
 
 .PHONY: help
@@ -140,61 +115,59 @@ help: ## Show this help
 	@grep -E -h '\s##\s' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 ###
+### Assets
+###
+
+$(testbin_created):
+	mkdir -p $(TESTBIN_DIR)
+	# a marker file must be created, because the date of the
+	# directory may update when content in it is created/updated,
+	# which would cause a rebuild / re-initialization of dependants
+	@touch $(testbin_created)
+
+# Build the binary without running generators
+.PHONY: $(BIN_FILENAME)
+$(BIN_FILENAME):
+	$(go_build)
+
+###
 ### KIND
 ###
 
-.PHONY: rund_kind
-run_kind: export KUBECONFIG = $(KIND_KUBECONFIG)
-run_kind: export BACKUP_ENABLE_LEADER_ELECTION = $(ENABLE_LEADER_ELECTION)
-run_kind: $(SETUP_KIND) ## Runs the operator in kind
-	go run ./main.go
+.PHONY: kind-setup
+kind-setup: ## Creates a kind instance if one does not exist yet.
+	@$(e2e_make) kind-setup
 
-$(KIND_BIN): export KUBECONFIG = $(KIND_KUBECONFIG)
-$(KIND_BIN): $(TESTBIN_DIR)
-	curl -Lo $(KIND_BIN) "https://kind.sigs.k8s.io/dl/v$(KIND_VERSION)/kind-$$(uname)-amd64"
-	@chmod +x $(KIND_BIN)
+.PHONY: kind-clean
+kind-clean: ## Removes the kind instance if it exists.
+	@$(e2e_make) kind-clean
 
-$(KIND_KUBECONFIG): export KUBECONFIG = $(KIND_KUBECONFIG)
-$(KIND_KUBECONFIG): $(KIND_BIN)
-	$(KIND_BIN) create cluster --name $(KIND_CLUSTER) --image kindest/node:$(KIND_NODE_VERSION)
-	@kubectl version
-	@kubectl cluster-info
-
-$(SETUP_KIND): export KUBECONFIG = $(KIND_KUBECONFIG)
-$(SETUP_KIND): $(KIND_KUBECONFIG)
-	@kubectl config use-context kind-$(KIND_CLUSTER)
-	@$(KUSTOMIZE_BUILD_CRD) | kubectl apply $(KIND_KUBECTL_ARGS) -f -
-	@touch $(SETUP_KIND)
-
-.PHONY: clean_kind
-clean_kind: export KUBECONFIG = $(KIND_KUBECONFIG)
-clean_kind: ## Remove the KIND Cluster
-	$(KIND_BIN) delete cluster --name $(KIND_CLUSTER) || true
-	@rm $(SETUP_KIND) || true
+.PHONY: kind-run
+kind-run: export KUBECONFIG = $(KIND_KUBECONFIG)
+kind-run: kind-setup install run ## Runs the operator on the local host but configured for the kind cluster
 
 ###
 ### E2E Test
 ###
 
-e2e_test: export E2E_IMAGE = $(E2E_IMG)
-e2e_test: setup_e2e_test $(KIND_KUBECONFIG) ## Runs the e2e test suite
-	$(MAKE) -C e2e run_bats -e KUBECONFIG=../$(KIND_KUBECONFIG)
+.PHONY: e2e-test
+e2e-test: export KUBECONFIG = $(KIND_KUBECONFIG)
+e2e-test: e2e-setup docker-build install ## Run the e2e tests
+	@$(e2e_make) test
 
-.PHONY: setup_e2e_test
-setup_e2e_test: $(SETUP_KIND) docker-build ## Run the e2e setup
-	$(MAKE) -C e2e install_bats
-	@$(KIND_BIN) load docker-image --name $(KIND_CLUSTER) $(E2E_IMG)
+.PHONY: e2e-setup
+e2e-setup: export KUBECONFIG = $(KIND_KUBECONFIG)
+e2e-setup: ## Run the e2e setup
+	@$(e2e_make) setup
 
-.PHONY: clean_e2e_setup
-clean_e2e_setup: export KUBECONFIG = $(KIND_KUBECONFIG)
-clean_e2e_setup: ## Clean the e2e setup (e.g. to rerun the setup_e2e_test)
-	kubectl delete ns k8up-system --ignore-not-found --force --grace-period=0 || true
-	@$(KUSTOMIZE_BUILD_CRD) | kubectl delete -f - || true
+.PHONY: e2e-clean-setup
+e2e-clean-setup: export KUBECONFIG = $(KIND_KUBECONFIG)
+e2e-clean-setup: ## Clean the e2e setup (e.g. to rerun the e2e-setup)
+	@$(e2e_make) clean-setup
 
-.PHONY: clean_e2e
-clean_e2e: clean_e2e_setup
-	docker images --filter "reference=$(E2E_REPO)" --format "{{.Repository }}:{{ .Tag }}" | xargs --no-run-if-empty docker rmi || true
-	$(MAKE) -C e2e clean
+.PHONY: e2e-clean
+e2e-clean: ## Remove all e2e-related resources (incl. all e2e Docker images)
+	@$(e2e_make) clean
 
 ###
 ### Documentation

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -1,0 +1,38 @@
+# Current Operator version
+VERSION ?= $(shell date +%Y-%m-%d_%H-%M-%S)
+VERSION := $(VERSION)
+
+# Default bundle image tag
+BUNDLE_IMG ?= controller-bundle:$(VERSION)
+
+IMG_TAG ?= latest
+
+BIN_FILENAME ?= $(PROJECT_ROOT_DIR)/k8up
+TESTBIN_DIR ?= $(PROJECT_ROOT_DIR)/testbin/bin
+
+CRD_FILE ?= k8up-crd.yaml
+CRD_FILE_LEGACY ?= k8up-crd-legacy.yaml
+CRD_ROOT_DIR ?= config/crd/apiextensions.k8s.io
+CRD_SPEC_VERSION ?= v1
+
+KIND_VERSION ?= 0.9.0
+KIND_NODE_VERSION ?= v1.18.8
+KIND ?= $(TESTBIN_DIR)/kind
+
+ENABLE_LEADER_ELECTION ?= false
+
+KIND_KUBECONFIG ?= $(TESTBIN_DIR)/kind-kubeconfig-$(KIND_NODE_VERSION)
+KIND_CLUSTER ?= k8up-$(KIND_NODE_VERSION)
+KIND_KUBECTL_ARGS ?= --validate=true
+
+E2E_TAG ?= e2e_$(shell sha1sum $(BIN_FILENAME) | cut -b-8)
+E2E_REPO ?= local.dev/k8up/e2e
+E2E_IMG = $(E2E_REPO):$(E2E_TAG)
+
+KUSTOMIZE ?= go run sigs.k8s.io/kustomize/kustomize/v3
+
+# Image URL to use all building/pushing image targets
+DOCKER_IMG ?= docker.io/vshn/k8up:$(IMG_TAG)
+QUAY_IMG ?= quay.io/vshn/k8up:$(IMG_TAG)
+
+testbin_created = $(TESTBIN_DIR)/.created

--- a/README.md
+++ b/README.md
@@ -97,17 +97,13 @@ K8up supports both OpenShift 3.11 clusters and newer Kubernetes clusters 1.16+.
 However, to support OpenShift 3.11 a legacy CRD definition with `apiextensions.k8s.io/v1beta1` is needed, while K8s 1.22+ only supports `apiextensions.k8s.io/v1`.
 You need `node` and `npm` to run the tests, as it runs with [DETIK][detik].
 
-First, setup a local e2e environment
-```
-make install_bats setup_e2e_test
-```
+To run e2e tests run:
 
-To run e2e tests for newer K8s versions run
 ```bash
 make e2e_test
 ```
 
-To test compatibility of k8up with OpenShift 3.11, we can run end-to-end tests as following:
+To test compatibility of k8up with OpenShift 3.11 (or any other specific K8s version), you can run end-to-end tests like this:
 
 ```bash
 make e2e_test -e CRD_SPEC_VERSION=v1beta1 -e KIND_NODE_VERSION=v1.13.12

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 
 K8up is a backup operator that will handle PVC and app backups on a k8s/OpenShift cluster.
 
-Just create a `schedule` and a `credentials` object in the namespace you’d like to backup. It’s that easy. K8up takes care of the rest. It also provides a Prometheus endpoint for monitoring.
+Just create a `schedule` and a `credentials` object in the namespace you’d like to backup.
+It’s that easy. K8up takes care of the rest. It also provides a Prometheus endpoint for monitoring.
 
 K8up is currently under heavy development and far from feature complete. But it should already be stable enough for production use.
 
@@ -33,12 +34,13 @@ You'll need:
 - docker
 - make
 
-These are the most common make targets: `build`, `test`, `docker-build`, `run`.
+These are the most common make targets: `build`, `test`, `docker-build`, `run`, `kind-run`.
 Run `make help` to get an overview over the relevant targets and their intentions.
 
-## Generate kubernetes code
+## Generate Kubernetes code
 
-If you make changes to the CRD structs you'll need to run code generation. This can be done with make:
+If you make changes to the CRD structs you'll need to run code generation.
+This can be done with make:
 
 ```bash
 make generate
@@ -57,7 +59,7 @@ You can run the operator in different ways:
 
 1. as a docker image (see [quickstart](https://sdk.operatorframework.io/docs/building-operators/golang/quickstart/))
 2. using `make run` (provide your own kubeconfig)
-3. using `make run_kind` (uses KIND to install a cluster in docker and provides its own kubeconfig in `testbin/`)
+3. using `make kind-run` (uses KIND to install a cluster in docker and provides its own kubeconfig in `testbin/`)
 4. using a configuration of your favorite IDE (see below for VSCode example)
 
 Example VSCode run configuration:
@@ -100,13 +102,13 @@ You need `node` and `npm` to run the tests, as it runs with [DETIK][detik].
 To run e2e tests run:
 
 ```bash
-make e2e_test
+make e2e-test
 ```
 
 To test compatibility of k8up with OpenShift 3.11 (or any other specific K8s version), you can run end-to-end tests like this:
 
 ```bash
-make e2e_test -e CRD_SPEC_VERSION=v1beta1 -e KIND_NODE_VERSION=v1.13.12
+make e2e-test -e CRD_SPEC_VERSION=v1beta1 -e KIND_NODE_VERSION=v1.13.12 -e KIND_KUBECTL_ARGS=--validate=false
 ```
 
 To remove the local KIND cluster and other resources, run

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Run `make help` to get an overview over the relevant targets and their intention
 
 If you make changes to the CRD structs you'll need to run code generation. This can be done with make:
 
-```
+```bash
 make generate
 ```
 
@@ -62,7 +62,7 @@ You can run the operator in different ways:
 
 Example VSCode run configuration:
 
-```
+```json
 {
   // Use IntelliSense to learn about possible attributes.
   // Hover to view descriptions of existing attributes.
@@ -103,23 +103,26 @@ make install_bats setup_e2e_test
 ```
 
 To run e2e tests for newer K8s versions run
-```
+```bash
 make e2e_test
 ```
 
 To test compatibility of k8up with OpenShift 3.11, we can run end-to-end tests as following:
-```
+
+```bash
 make e2e_test -e CRD_SPEC_VERSION=v1beta1 -e KIND_NODE_VERSION=v1.13.12
 ```
 
 To remove the local KIND cluster and other resources, run
-```
+
+```bash
 make clean
 ```
 
 ## Example configurations
 
-There are a number of example configurations in [`config/samples`](config/samples). Apply them using `kubectl apply -f config/samples/somesample.yaml`
+There are a number of example configurations in [`config/samples`](config/samples).
+Apply them using `kubectl apply -f config/samples/somesample.yaml`
 
 [build]: https://github.com/vshn/k8up/actions?query=workflow%3ABuild
 [releases]: https://github.com/vshn/k8up/releases

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -1,23 +1,55 @@
-
 # Set Shell to bash, otherwise some targets fail with dash/zsh etc.
 SHELL := /bin/bash
 
-BATS := node_modules/.bin/bats
+# Disable built-in rules
+MAKEFLAGS += --no-builtin-rules
+MAKEFLAGS += --no-builtin-variables
+.SUFFIXES:
+.SECONDARY:
 
-.PHONY: install_bats
-install_bats: $(BATS)
+PROJECT_ROOT_DIR = ..
+include ../Makefile.vars.mk
+include kind.mk
 
-.PHONY: run_bats
-run_bats: export KUBECONFIG = $(KIND_KUBECONFIG)
-run_bats: install_bats
-	@mkdir -p debug || true
-	@$(BATS) .
+uname_s := $(shell uname -s)
+ifeq ($(uname_s),Linux)
+	xargs := xargs --no-run-if-empty
+else
+	xargs := xargs
+endif
+
+bats := node_modules/.bin/bats
+
+.DEFAULT_GOAL := help
+
+.PHONY: test
+test: export KUBECONFIG = $(KIND_KUBECONFIG)
+test: export E2E_IMAGE = $(E2E_IMG)
+test: setup ## Run the E2E tests
+	@mkdir -p debug
+	@$(KIND) load docker-image --name $(KIND_CLUSTER) $(E2E_IMG)
+	@$(bats) .
+
+.PHONY: setup
+setup: export KUBECONFIG = $(KIND_KUBECONFIG)
+setup: $(bats) kind-setup ## Run the e2e setup
+
+.PHONY: clean-setup
+clean-setup: export KUBECONFIG = $(KIND_KUBECONFIG)
+clean-setup: kind-clean ## Clean the e2e setup (e.g. to rerun the setup)
 
 .PHONY: clean
-clean:
+clean: clean-setup ## Remove all e2e-related resources (incl. all e2e Docker images)
+	docker images --filter "reference=$(E2E_REPO)" --format "{{.Repository }}:{{ .Tag }}" | $(xargs) docker rmi || true
 	rm -r debug node_modules || true
 
-$(BATS): node_modules
+.PHONY: help
+help: ## Show this help
+	@grep -E -h '\s##\s' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
-node_modules:
+###
+### Artifacts
+###
+
+$(bats):
 	@npm install

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -2,19 +2,22 @@
 # Set Shell to bash, otherwise some targets fail with dash/zsh etc.
 SHELL := /bin/bash
 
+BATS := node_modules/.bin/bats
+
 .PHONY: install_bats
-install_bats: node_modules/.bin/bats
+install_bats: $(BATS)
 
 .PHONY: run_bats
 run_bats: export KUBECONFIG = $(KIND_KUBECONFIG)
-run_bats:
+run_bats: install_bats
 	@mkdir -p debug || true
-	@node_modules/.bin/bats .
+	@$(BATS) .
 
+.PHONY: clean
 clean:
 	rm -r debug node_modules || true
 
-node_modules/.bin/bats: node_modules
+$(BATS): node_modules
 
 node_modules:
 	@npm install

--- a/e2e/kind.mk
+++ b/e2e/kind.mk
@@ -1,0 +1,42 @@
+kind_marker := $(TESTBIN_DIR)/.kind-setup_complete
+
+curl_args ?= --location --fail --silent --show-error
+
+.DEFAULT_TARGET: kind-setup
+
+.PHONY: kind-setup
+kind-setup: export KUBECONFIG = $(KIND_KUBECONFIG)
+kind-setup: $(kind_marker) ## Creates the kind cluster
+
+.PHONY: kind-clean
+kind-clean: export KUBECONFIG = $(KIND_KUBECONFIG)
+kind-clean: ## Remove the kind Cluster
+	@$(KIND) delete cluster --name $(KIND_CLUSTER) || true
+	@rm $(KIND) $(kind_marker) $(KIND_KUBECONFIG) || true
+
+###
+### Artifacts
+###
+
+$(KIND): export KUBECONFIG = $(KIND_KUBECONFIG)
+$(KIND): $(testbin_created)
+	curl $(curl_args) --output "$(KIND)" "https://kind.sigs.k8s.io/dl/v$(KIND_VERSION)/kind-$$(uname)-amd64"
+	@chmod +x $(KIND)
+
+$(KIND_KUBECONFIG): export KUBECONFIG = $(KIND_KUBECONFIG)
+$(KIND_KUBECONFIG): $(KIND)
+	$(KIND) create cluster --name $(KIND_CLUSTER) --image kindest/node:$(KIND_NODE_VERSION)
+	@kubectl version
+	@kubectl cluster-info
+
+$(kind_marker): export KUBECONFIG = $(KIND_KUBECONFIG)
+$(kind_marker): $(KIND_KUBECONFIG)
+	@kubectl config use-context kind-$(KIND_CLUSTER)
+	@touch $(kind_marker)
+
+$(testbin_created):
+	mkdir -p $(TESTBIN_DIR)
+	# a marker file must be created, because the date of the
+	# directory may update when content in it is created/updated,
+	# which would cause a rebuild / re-initialization of dependants
+	@touch $(testbin_created)


### PR DESCRIPTION
## Summary

Re-organized the Makefile with regards to #198 .

Left to do:
- [x] Actually extract code from `./Makefile` into another file

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.
- ~~Update tests.~~
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
