### PR TITLE
Ensure backwards compatibility of GLOBALSECRETACCESSKEY variable

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -30,10 +30,10 @@ type Configuration struct {
 	GlobalRestoreS3AccessKey         string `koanf:"globalrestores3accesskeyid"`
 	GlobalRestoreS3Bucket            string `koanf:"globalrestores3bucket"`
 	GlobalRestoreS3Endpoint          string `koanf:"globalrestores3endpoint"`
-	GlobalRestoreS3SecretAccessKey   string `koanf:"globalrestores3secretaccesskeyid"`
+	GlobalRestoreS3SecretAccessKey   string `koanf:"globalrestores3secretaccesskey"`
 	GlobalS3Bucket                   string `koanf:"globals3bucket"`
 	GlobalS3Endpoint                 string `koanf:"globals3endpoint"`
-	GlobalSecretAccessKey            string `koanf:"globalsecretaccesskeyid"`
+	GlobalSecretAccessKey            string `koanf:"globalsecretaccesskey"`
 	GlobalStatsURL                   string `koanf:"globalstatsurl"`
 	GlobalConcurrentArchiveJobsLimit int    `koanf:"globalconcurrentarchivejobslimit"`
 	GlobalConcurrentBackupJobsLimit  int    `koanf:"globalconcurrentbackupjobslimit"`


### PR DESCRIPTION
## Summary

One complaint in #256 was, that the AWS S3 Secret Access Key is not passed on to the container. This seems to be a regression from the refactoring work.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
