### PR TITLE
Add junit reporting for e2e tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,9 +60,13 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Run e2e tests
-      run: make crd e2e-test -e CRD_SPEC_VERSION=${{ matrix.crd-spec-version }} -e KIND_NODE_VERSION=${{ matrix.kind-node-version }} -e KIND_KUBECTL_ARGS=--validate=false
-    - name: Show e2e debug logs
-      run: cat e2e/debug/detik/*
+      run: make crd e2e-test -e CRD_SPEC_VERSION=${{ matrix.crd-spec-version }} -e KIND_NODE_VERSION=${{ matrix.kind-node-version }} -e KIND_KUBECTL_ARGS=--validate=false -e bats_args="-F junit || true"
+    - name: Publish Test Report
+      uses: mikepenz/action-junit-report@v1
+      with:
+        report_paths: '**/e2e/TestReport-*.xml'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        check_name: e2e-report (${{ matrix.kind-node-version }}, ${{ matrix.crd-spec-version }})
   image:
     runs-on: ubuntu-latest
     steps:

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,1 @@
+TestReport*.xml

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -19,6 +19,7 @@ else
 endif
 
 bats := node_modules/.bin/bats
+bats_args ?=
 
 .DEFAULT_GOAL := help
 
@@ -28,7 +29,7 @@ test: export E2E_IMAGE = $(E2E_IMG)
 test: setup ## Run the E2E tests
 	@mkdir -p debug
 	@$(KIND) load docker-image --name $(KIND_CLUSTER) $(E2E_IMG)
-	@$(bats) .
+	@$(bats) . $(bats_args)
 
 .PHONY: setup
 setup: export KUBECONFIG = $(KIND_KUBECONFIG)


### PR DESCRIPTION
## Summary

* Bats supports formatting tests with junit, and there's a cool junit GH action, so let's marry them!
* On successful runs, the reports may be added to the "Lint" workflow suite. [This is a bug by GitHub](https://github.com/mikepenz/action-junit-report/issues/34) and just of a cosmetic nature.

An example of a failing test can be found here: https://github.com/vshn/k8up/pull/259/checks?check_run_id=1651595468

![image](https://user-images.githubusercontent.com/12159026/103680109-fb485b80-4f85-11eb-8d94-e151c5a27cff.png)

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update tests.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
