### PR TITLE
Fix Check Job Creation escapade

### DIFF
--- a/executor/archive.go
+++ b/executor/archive.go
@@ -68,7 +68,9 @@ func (a *ArchiveExecutor) startArchive(archiveJob *batchv1.Job, archive *k8upv1a
 	if err != nil {
 		if !apierrors.IsAlreadyExists(err) {
 			a.Log.Error(err, "could not create job")
-			a.SetConditionFalse(ConditionJobCreated, "could not create job: %v", err)
+			a.SetConditionFalse(ConditionJobCreated,
+				"could not create archive job '%v/%v': %v",
+				archiveJob.Namespace, archiveJob.Name, err)
 			return
 		}
 	}


### PR DESCRIPTION
## Summary

Besides two refactoring (which are their own commits and which I could extract into their own PR if needed), this PR aims to fix that a lot of `Check` jobs are created and scheduled, even though they already exist, rsp. have been scheduled before.
The culprit I have identified was that the `Check.Status.Started` property was never set. But it's that property which the check handler uses to determine whether it should create & schedule another check job.

The logic of the Check handler was adjusted to match the logic of the other handlers in that regard.

This PR is part of the investigations of #256 and is based on #260. Fixes #257 .

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] ~Update the documentation.~
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
