### PR TITLE
Better distinguish between non-standard and k8up generative schedules

### DIFF
--- a/docs/modules/ROOT/pages/references/schedule-specification.adoc
+++ b/docs/modules/ROOT/pages/references/schedule-specification.adoc
@@ -35,6 +35,11 @@ The following non-standard schedules are supported:
 |Run once at fixed intervals, starting at the time it's added or K8up is started up.
  `<duration>` is a string accepted by http://golang.org/pkg/time/#ParseDuration[time.ParseDuration] (e.g. `1h30m`).
 |
+|===
+
+.K8up-specific schedule specification
+|===
+|Entry in Spec|Description|Equivalent to
 
 |`@yearly-random` or `@annually-random`
 |Run once a year, randomized start time and date
@@ -57,7 +62,7 @@ The following non-standard schedules are supported:
 |`52 * * * *` (example)
 |===
 
-NOTE: The day-of-month in the `@monthly` or `@yearly` is capped at the number 27.
+NOTE: The day-of-month in the `@monthly-random` or `@yearly-random` is capped at the number 27.
       This is because there are months that have between 27 and 31 days.
       Cron skips a job when the day-of-month is higher than the current month has  days in it.
       This is to prevent skipping backups and alerts from being fired.


### PR DESCRIPTION
## Summary

* Better distinguish between non-standard and k8up generative schedules

see discussion in #260 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
