### PR TITLE
Avoid reconciliation loops with predicates

### DIFF
--- a/controllers/archive_controller.go
+++ b/controllers/archive_controller.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	k8upv1alpha1 "github.com/vshn/k8up/api/v1alpha1"
 	"github.com/vshn/k8up/cfg"
@@ -53,5 +54,6 @@ func (r *ArchiveReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 func (r *ArchiveReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&k8upv1alpha1.Archive{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)
 }

--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	k8upv1alpha1 "github.com/vshn/k8up/api/v1alpha1"
 	"github.com/vshn/k8up/cfg"
@@ -63,5 +64,6 @@ func (r *BackupReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 func (r *BackupReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&k8upv1alpha1.Backup{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)
 }

--- a/controllers/check_controller.go
+++ b/controllers/check_controller.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	k8upv1alpha1 "github.com/vshn/k8up/api/v1alpha1"
 	"github.com/vshn/k8up/cfg"
@@ -55,5 +56,6 @@ func (r *CheckReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 func (r *CheckReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&k8upv1alpha1.Check{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)
 }

--- a/controllers/prune_controller.go
+++ b/controllers/prune_controller.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	k8upv1alpha1 "github.com/vshn/k8up/api/v1alpha1"
 	"github.com/vshn/k8up/cfg"
@@ -57,5 +58,6 @@ func (r *PruneReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 func (r *PruneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&k8upv1alpha1.Prune{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)
 }

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	k8upv1alpha1 "github.com/vshn/k8up/api/v1alpha1"
 	"github.com/vshn/k8up/cfg"
@@ -57,5 +58,6 @@ func (r *RestoreReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 func (r *RestoreReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&k8upv1alpha1.Restore{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)
 }

--- a/controllers/schedule_controller.go
+++ b/controllers/schedule_controller.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	k8upv1alpha1 "github.com/vshn/k8up/api/v1alpha1"
@@ -52,5 +53,6 @@ func (r *ScheduleReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 func (r *ScheduleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&k8upv1alpha1.Schedule{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)
 }


### PR DESCRIPTION
## Summary

From the godoc:

---
GenerationChangedPredicate implements a default update predicate function on Generation change.
This predicate will skip update events that have no change in the object's metadata.generation field. 
The metadata.generation field of an object is incremented by the API server when writes are made to the spec field of an object. 
This allows a controller to ignore update events where the spec is unchanged, and only the metadata and/or status fields are changed.
For CustomResource objects the Generation is only incremented when the status subresource is enabled.
Caveats:
* The assumption that the Generation is incremented only on writing to the spec does not hold for all APIs. 
  E.g For Deployment objects the Generation is also incremented on writes to the metadata.annotations field. 
  For object types other than CustomResources be sure to verify which fields will trigger a Generation increment when they are written to.
* With this predicate, any update events with writes only to the status field will not be reconciled. 
  So in the event that the status block is overwritten or wiped by someone else the controller will not self-correct to restore the correct status.

---
* In short: This should avoid a reconciliation loop when we update the status by ourselves. but also means that if someone else manually updates the status field then no reconciliation will be triggered either. I don't a reason why a user would do that, but hey...
* May also be relevant for #257 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
