### PR TITLE
Load the e2e image into KIND in its own make-target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ MAKEFLAGS += --no-builtin-variables
 PROJECT_ROOT_DIR = .
 include Makefile.vars.mk
 
-e2e_make := $(MAKE) -C e2e -e 'VERSION=$(VERSION)'
+e2e_make := $(MAKE) -C e2e
 go_build ?= CGO_ENABLED=0 go build -o $(BIN_FILENAME) main.go
 
 # Options for 'bundle-build'
@@ -145,6 +145,9 @@ kind-clean: ## Removes the kind instance if it exists.
 .PHONY: kind-run
 kind-run: export KUBECONFIG = $(KIND_KUBECONFIG)
 kind-run: kind-setup install run ## Runs the operator on the local host but configured for the kind cluster
+
+kind-e2e-image: docker-build
+	$(e2e_make) kind-e2e-image
 
 ###
 ### E2E Test

--- a/Makefile
+++ b/Makefile
@@ -13,22 +13,6 @@ include Makefile.vars.mk
 e2e_make := $(MAKE) -C e2e
 go_build ?= CGO_ENABLED=0 go build -o $(BIN_FILENAME) main.go
 
-# Options for 'bundle-build'
-ifneq ($(origin CHANNELS), undefined)
-BUNDLE_CHANNELS := --channels=$(CHANNELS)
-endif
-ifneq ($(origin DEFAULT_CHANNEL), undefined)
-BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
-endif
-BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
-
-# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
-else
-GOBIN=$(shell go env GOBIN)
-endif
-
 # Run tests (see https://sdk.operatorframework.io/docs/building-operators/golang/references/envtest-setup)
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 
@@ -98,13 +82,6 @@ docker-build: $(BIN_FILENAME) ## Build the docker image
 docker-push: ## Push the docker image
 	docker push $(DOCKER_IMG)
 	docker push $(QUAY_IMG)
-
-.PHONY: bundle
-bundle: generate ## Generate bundle manifests and metadata, then validate generated files.
-	operator-sdk generate kustomize manifests -q
-	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
-	operator-sdk bundle validate ./bundle
 
 clean: export KUBECONFIG = $(KIND_KUBECONFIG)
 clean: e2e-clean kind-clean ## Cleans up the generated resources

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -1,6 +1,5 @@
 # Current Operator version
-VERSION ?= $(shell date +%Y-%m-%d_%H-%M-%S)
-VERSION := $(VERSION)
+VERSION ?=
 
 # Default bundle image tag
 BUNDLE_IMG ?= controller-bundle:$(VERSION)

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -1,9 +1,3 @@
-# Current Operator version
-VERSION ?=
-
-# Default bundle image tag
-BUNDLE_IMG ?= controller-bundle:$(VERSION)
-
 IMG_TAG ?= latest
 
 BIN_FILENAME ?= $(PROJECT_ROOT_DIR)/k8up

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -26,10 +26,12 @@ bats_args ?=
 .PHONY: test
 test: export KUBECONFIG = $(KIND_KUBECONFIG)
 test: export E2E_IMAGE = $(E2E_IMG)
-test: setup ## Run the E2E tests
+test: setup kind-e2e-image ## Run the E2E tests
 	@mkdir -p debug
-	@$(KIND) load docker-image --name $(KIND_CLUSTER) $(E2E_IMG)
 	@$(bats) . $(bats_args)
+
+kind-e2e-image: kind-setup ## Load the e2e container image onto e2e cluster
+	@$(KIND) load docker-image --name $(KIND_CLUSTER) $(E2E_IMG)
 
 .PHONY: setup
 setup: export KUBECONFIG = $(KIND_KUBECONFIG)

--- a/e2e/test1.bats
+++ b/e2e/test1.bats
@@ -18,6 +18,7 @@ DEBUG_DETIK="true"
   run kubectl apply -f debug/test1.yaml
   echo "$output"
 
-  try "at most 20 times every 2s to find 1 pod named 'k8up-operator' with 'status' being 'running'"
+  try "at most 10 times every 2s to find 1 pod named 'k8up-operator' with '.spec.containers[*].image' being '${E2E_IMAGE}'"
+  try "at most 10 times every 2s to find 1 pod named 'k8up-operator' with 'status' being 'running'"
 
 }


### PR DESCRIPTION
## Summary

* This should allow cases for local development where the image should be updated
without having to run the e2e tests themselves (e.g. manually)
* Further checks in the e2e whether the new image is being seen, and not the old pod from the previous replicaset.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update tests.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
