### PR TITLE
Improve failure handling in GH e2e report workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,9 +60,10 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Run e2e tests
-      run: make crd e2e-test -e CRD_SPEC_VERSION=${{ matrix.crd-spec-version }} -e KIND_NODE_VERSION=${{ matrix.kind-node-version }} -e KIND_KUBECTL_ARGS=--validate=false -e bats_args="-F junit || true"
+      run: make crd e2e-test -e CRD_SPEC_VERSION=${{ matrix.crd-spec-version }} -e KIND_NODE_VERSION=${{ matrix.kind-node-version }} -e KIND_KUBECTL_ARGS=--validate=false -e bats_args="-F junit"
     - name: Publish Test Report
       uses: mikepenz/action-junit-report@v1
+      if: success() || failure()
       with:
         report_paths: '**/e2e/TestReport-*.xml'
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

There is a `failure()` conditional for workflow steps, let's use that instead of || true

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
