### PR TITLE
Show partial release notes for PreReleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,10 @@ jobs:
       uses: mikepenz/release-changelog-builder-action@v1.4.1
       with:
         configuration: ".github/changelog-configuration.json"
-        # Prereleases still get a changelog, but the next full release gets a diff since the last full release,
-        # combining possible changelogs of all previous prereleases inbetween.
-        ignorePreReleases: "true"
+        # PreReleases still get a changelog, but the next full release gets a diff since the last full release,
+        # combining possible changelogs of all previous PreReleases in between. PreReleases show a partial changelog
+        # since last PreRelease.
+        ignorePreReleases: "${{ !contains(github.ref, '-rc') }}"
         outputFile: .github/release-notes.md
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

when creating a tag with 'rc' in its name, this should build a changelog that shows a partial changelog since the last prerelease, and the full one when fully released. That makes it easier to follow changes between prereleases.

This is a suggestion from https://github.com/mikepenz/release-changelog-builder-action/issues/154#issuecomment-758117389, which I quite like and didn't think of earlier.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Link this PR to related issues.
