### PR TITLE
Fix Application of Global Memory Limit

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -109,9 +109,9 @@ func (c Configuration) GetGlobalDefaultResources() (res corev1.ResourceRequireme
 	}
 	if r, err := resource.ParseQuantity(c.GlobalMemoryResourceLimit); err == nil && c.GlobalMemoryResourceLimit != "" {
 		if res.Limits == nil {
-			res.Requests = make(corev1.ResourceList)
+			res.Limits = make(corev1.ResourceList)
 		}
-		res.Requests[corev1.ResourceCPU] = r
+		res.Limits[corev1.ResourceMemory] = r
 	}
 	if r, err := resource.ParseQuantity(c.GlobalCPUResourceLimit); err == nil && c.GlobalCPUResourceLimit != "" {
 		if res.Limits == nil {


### PR DESCRIPTION
## Summary

The global memory limit property was accidentally applied as the CPU request. Related to #276.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
