### PR TITLE
Rename new global environment vars

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -35,15 +35,15 @@ type Configuration struct {
 	GlobalS3Endpoint                 string `koanf:"globals3endpoint"`
 	GlobalSecretAccessKey            string `koanf:"globalsecretaccesskey"`
 	GlobalStatsURL                   string `koanf:"globalstatsurl"`
-	GlobalConcurrentArchiveJobsLimit int    `koanf:"globalconcurrentarchivejobslimit"`
-	GlobalConcurrentBackupJobsLimit  int    `koanf:"globalconcurrentbackupjobslimit"`
-	GlobalConcurrentCheckJobsLimit   int    `koanf:"globalconcurrentcheckjobslimit"`
-	GlobalConcurrentPruneJobsLimit   int    `koanf:"globalconcurrentprunejobslimit"`
-	GlobalConcurrentRestoreJobsLimit int    `koanf:"globalconcurrentrestorejobslimit"`
-	GlobalCPUResourceRequest         string `koanf:"globalcpu-request"`
-	GlobalCPUResourceLimit           string `koanf:"globalcpu-limit"`
-	GlobalMemoryResourceRequest      string `koanf:"globalmemory-request"`
-	GlobalMemoryResourceLimit        string `koanf:"globalmemory-limit"`
+	GlobalConcurrentArchiveJobsLimit int    `koanf:"global-concurrent-archive-jobs-limit"`
+	GlobalConcurrentBackupJobsLimit  int    `koanf:"global-concurrent-backup-jobs-limit"`
+	GlobalConcurrentCheckJobsLimit   int    `koanf:"global-concurrent-check-jobs-limit"`
+	GlobalConcurrentPruneJobsLimit   int    `koanf:"global-concurrent-prune-jobs-limit"`
+	GlobalConcurrentRestoreJobsLimit int    `koanf:"global-concurrent-restore-jobs-limit"`
+	GlobalCPUResourceRequest         string `koanf:"global-cpu-request"`
+	GlobalCPUResourceLimit           string `koanf:"global-cpu-limit"`
+	GlobalMemoryResourceRequest      string `koanf:"global-memory-request"`
+	GlobalMemoryResourceLimit        string `koanf:"global-memory-limit"`
 	BackupImage                      string `koanf:"image"`
 	MetricsBindAddress               string `koanf:"metrics-bindaddress"`
 	PodExecRoleName                  string `koanf:"podexecrolename"`

--- a/docs/modules/ROOT/pages/references/config-reference.adoc
+++ b/docs/modules/ROOT/pages/references/config-reference.adoc
@@ -14,16 +14,16 @@ The Operator can be configured in two ways:
 `BACKUP_ENABLE_LEADER_ELECTION`:: enable leader election within the operator Pod, default: `true`
 `BACKUP_FILEEXTENSIONANNOTATION`:: set the annotation name where the file extension is stored for backup commands, default `k8up.syn.tools/file-extension`
 `BACKUP_GLOBALACCESSKEYID`:: set the S3 access key id to be used globally
-`BACKUP_GLOBALCONCURRENTARCHIVEJOBSLIMIT`:: set the limit of concurrent archive jobs
-`BACKUP_GLOBALCONCURRENTBACKUPJOBSLIMIT`:: set the limit of concurrent backup jobs
-`BACKUP_GLOBALCONCURRENTCHECKJOBSLIMIT`:: set the limit of concurrent check jobs
-`BACKUP_GLOBALCONCURRENTPRUNEJOBSLIMIT`:: set the limit of concurrent prune jobs
-`BACKUP_GLOBALCONCURRENTRESTOREJOBSLIMIT`:: set the limit of concurrent restore jobs
-`BACKUP_GLOBALCPU_LIMIT`:: set the CPU limit for scheduled jobs
-`BACKUP_GLOBALCPU_REQUEST`:: set the CPU request for scheduled jobs
+`BACKUP_GLOBAL_CONCURRENT_ARCHIVE_JOBS_LIMIT`:: set the limit of concurrent archive jobs
+`BACKUP_GLOBAL_CONCURRENT_BACKUP_JOBS_LIMIT`:: set the limit of concurrent backup jobs
+`BACKUP_GLOBAL_CONCURRENT_CHECK_JOBS_LIMIT`:: set the limit of concurrent check jobs
+`BACKUP_GLOBAL_CONCURRENT_PRUNE_JOBS_LIMIT`:: set the limit of concurrent prune jobs
+`BACKUP_GLOBAL_CONCURRENT_RESTORE_JOBS_LIMIT`:: set the limit of concurrent restore jobs
+`BACKUP_GLOBAL_CPU_LIMIT`:: set the CPU limit for scheduled jobs
+`BACKUP_GLOBAL_CPU_REQUEST`:: set the CPU request for scheduled jobs
 `BACKUP_GLOBALKEEPJOBS`:: set the number of old backup jobs to keep globally
-`BACKUP_GLOBALMEMORY_LIMIT`:: set the memory limit for scheduled jobs
-`BACKUP_GLOBALMEMORY_REQUEST`:: set the memory request for scheduled jobs
+`BACKUP_GLOBAL_MEMORY_LIMIT`:: set the memory limit for scheduled jobs
+`BACKUP_GLOBAL_MEMORY_REQUEST`:: set the memory request for scheduled jobs
 `BACKUP_GLOBALREPOPASSWORD`:: set the restic repository password to be used globally
 `BACKUP_GLOBALRESTORES3ACCESKEYID`:: set the global restore S3 accessKeyID for restores
 `BACKUP_GLOBALRESTORES3BUCKET`:: set the global restore S3 bucket for restores


### PR DESCRIPTION
## Summary

These vars in question have not yet been released into stable version yet. Better now than later.
The rename should make it more natural to define env vars and easier to read and remember. 
Changing other parameters would be breaking.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
