### PR TITLE
Add config option to enable verbose logging and set default to 'info'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ build: generate fmt vet $(BIN_FILENAME) ## Build manager binary
 
 .PHONY: run
 run: export BACKUP_ENABLE_LEADER_ELECTION = $(ENABLE_LEADER_ELECTION)
+run: export BACKUP_LOG_LEVEL = debug
 run: fmt vet ## Run against the configured Kubernetes cluster in ~/.kube/config
 	go run ./main.go
 

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -2,6 +2,7 @@ package cfg
 
 import (
 	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -52,7 +53,8 @@ type Configuration struct {
 	RestartPolicy                    string `koanf:"restartpolicy"`
 
 	// Enabling this will ensure there is only one active controller manager.
-	EnableLeaderElection bool `koanf:"enable-leader-election"`
+	EnableLeaderElection bool   `koanf:"enable-leader-election"`
+	LogLevel             string `koanf:"log-level"`
 }
 
 var (

--- a/docs/modules/ROOT/pages/references/config-reference.adoc
+++ b/docs/modules/ROOT/pages/references/config-reference.adoc
@@ -35,6 +35,7 @@ The Operator can be configured in two ways:
 `BACKUP_GLOBALSTATSURL`:: set the URL of wrestic to post additional metrics globally, default `""`
 `BACKUP_IMAGE`:: URL of the restic image, default: `172.30.1.1:5000/myproject/restic`
 `BACKUP_JOBNAME`:: names for the backup job objects in OpenShift, default: `backupjob`
+`BACKUP_LOG_LEVEL`:: Set to "debug" to enable verbose logging, default: `info`
 `BACKUP_METRICS_BINDADDRESS`:: set the bind address for the prometheus endpoint, default: `:8080`
 `BACKUP_PODEXECACCOUNTNAME`:: set the service account name that should be used for the pod command execution, default: `pod-executor`
 `BACKUP_PODEXECROLENAME`:: set the role name that should be used for pod command execution, default `pod-executor`

--- a/e2e/test1/deployment.yaml
+++ b/e2e/test1/deployment.yaml
@@ -10,3 +10,6 @@ spec:
       containers:
       - name: k8up
         image: $E2E_IMAGE
+        env:
+        - name: BACKUP_LOG_LEVEL
+          value: debug

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/prometheus/client_golang v1.9.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.7.0
+	go.uber.org/zap v1.15.0
 	k8s.io/api v0.20.1
 	k8s.io/apimachinery v0.20.1
 	k8s.io/client-go v0.20.1

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 
+	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -45,9 +46,12 @@ func init() {
 
 func main() {
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
-
 	loadEnvironmentVariables()
+	level := zapcore.InfoLevel
+	if strings.EqualFold(cfg.Config.LogLevel, "debug") {
+		level = zapcore.DebugLevel
+	}
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.Level(level)))
 
 	setupLog.WithValues("version", version, "date", date, "commit", commit).Info("Starting K8up operator")
 	executor.GetExecutor()


### PR DESCRIPTION
## Summary

* Adds Env var "BACKUP_LOG_LEVEL" to set Operator's logging level
* Sets default log level to `info`
* Only other option implemented is `debug`

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.
- [ ] ~Update tests.~
- [ ] ~Link this PR to related issues.~

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
