### PR TITLE
Change default backup image to quay.io/vshn/wrestic

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -71,7 +71,7 @@ func NewDefaultConfig() *Configuration {
 		ServiceAccount:          "pod-executor",
 		BackupCheckSchedule:     "0 0 * * 0",
 		GlobalKeepJobs:          6,
-		BackupImage:             "172.30.1.1:5000/myproject/restic",
+		BackupImage:             "quay.io/vshn/wrestic:latest",
 		PodExecRoleName:         "pod-executor",
 		RestartPolicy:           "OnFailure",
 		MetricsBindAddress:      ":8080",

--- a/docs/modules/ROOT/pages/references/config-reference.adoc
+++ b/docs/modules/ROOT/pages/references/config-reference.adoc
@@ -33,7 +33,7 @@ The Operator can be configured in two ways:
 `BACKUP_GLOBALS3ENDPOINT`:: set the S3 endpoint to be used globally
 `BACKUP_GLOBALSECRETACCESSKEY`:: set the S3 secret access key to be used globally
 `BACKUP_GLOBALSTATSURL`:: set the URL of wrestic to post additional metrics globally, default `""`
-`BACKUP_IMAGE`:: URL of the restic image, default: `172.30.1.1:5000/myproject/restic`
+`BACKUP_IMAGE`:: URL of the restic image, default: `quay.io/vshn/wrestic:latest`
 `BACKUP_JOBNAME`:: names for the backup job objects in OpenShift, default: `backupjob`
 `BACKUP_LOG_LEVEL`:: Set to "debug" to enable verbose logging, default: `info`
 `BACKUP_METRICS_BINDADDRESS`:: set the bind address for the prometheus endpoint, default: `:8080`

--- a/executor/restore_test.go
+++ b/executor/restore_test.go
@@ -287,8 +287,8 @@ func jobMatcher(restoreType string, additionalArgs []string, env Elements, volum
 				"Spec": MatchFields(IgnoreExtras, Fields{
 					"Volumes": MatchAllElements(volumeID, volumes),
 					"Containers": MatchAllElements(containerID, Elements{
-						"172.30.1.1:5000/myproject/restic" + strings.Join(additionalArgs, ","): MatchFields(IgnoreExtras, Fields{
-							"Image":        Equal("172.30.1.1:5000/myproject/restic"),
+						"quay.io/vshn/wrestic:latest" + strings.Join(additionalArgs, ","): MatchFields(IgnoreExtras, Fields{
+							"Image":        Equal("quay.io/vshn/wrestic:latest"),
 							"Args":         ContainElements(additionalArgs),
 							"Env":          MatchAllElements(envID, env),
 							"VolumeMounts": MatchAllElements(volumeMountID, volumeMounts),


### PR DESCRIPTION
## Summary

The backup image with hardcoded IP and example repository does not bring any value.
For generic purpose, the image being used is wrestic anyway.

Technically, this is a breaking change. However, since all users were required to set this property anyway, this should not have a major impact.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.
- [x] ~Link this PR to related issues.~

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
