### PR TITLE
Avoid name clash by using scheduler name as prefix and random suffix

### DIFF
--- a/executor/restore_test.go
+++ b/executor/restore_test.go
@@ -280,6 +280,7 @@ func jobMatcher(restoreType string, additionalArgs []string, env Elements, volum
 			"Labels": MatchAllKeys(Keys{
 				"k8upjob":           Equal("true"),
 				"k8upjob/exclusive": Equal("false"),
+				"k8up.io/type":      Equal("restore"),
 			}),
 		}),
 		"Spec": MatchFields(IgnoreExtras, Fields{

--- a/job/job.go
+++ b/job/job.go
@@ -26,8 +26,11 @@ const (
 	// K8uplabel is a label that is required for the operator to differentiate
 	// batchv1.job objects managed by k8up from others.
 	K8uplabel = "k8upjob"
-	// K8upExclusive is needed to determine if a given job is consideret exclusive or not.
+	// K8upExclusive is needed to determine if a given job is considered exclusive or not.
 	K8upExclusive = "k8upjob/exclusive"
+
+	// K8upTypeLabel is the label key that identifies the job type.
+	K8upTypeLabel = "k8up.io/type"
 )
 
 // Config represents the whole context for a given job. It contains everything
@@ -70,7 +73,8 @@ func GetGenericJob(obj Object, config Config) (*batchv1.Job, error) {
 			Name:      obj.GetMetaObject().GetName(),
 			Namespace: obj.GetMetaObject().GetNamespace(),
 			Labels: map[string]string{
-				K8uplabel: "true",
+				K8uplabel:     "true",
+				K8upTypeLabel: obj.GetType().String(),
 			},
 		},
 		Spec: batchv1.JobSpec{

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -107,3 +107,30 @@ func TestScheduler_SyncSchedules(t *testing.T) {
 		})
 	}
 }
+
+func Test_generateName(t *testing.T) {
+	tests := map[string]struct {
+		jobType        k8upv1alpha1.JobType
+		prefix         string
+		expectedPrefix string
+	}{
+		"GivenShortPrefix_WhenGenerate_ThenUseFullPrefix": {
+			jobType:        k8upv1alpha1.ArchiveType,
+			prefix:         "my-schedule",
+			expectedPrefix: "my-schedule-archive-",
+		},
+		"GivenLongPrefix_WhenGenerate_ThenShortenPrefix": {
+			jobType:        k8upv1alpha1.ArchiveType,
+			prefix:         "my-schedule-with-a-really-long-name-that-could-clash-with-max-length",
+			expectedPrefix: "my-schedule-with-a-really-long-name-that-could-cl-archive-",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			name := generateName(tt.jobType, tt.prefix)
+			assert.Contains(t, name, tt.expectedPrefix)
+			assert.LessOrEqual(t, len(name), 63)
+			assert.Equal(t, len(name), len(tt.expectedPrefix)+5)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

* When multiple schedules are created in the same namespace, the names could clash if the are scheduled in the same second.
* It replaces the unix timestamp suffix with a 5-char randomized string in the job name. Since the creation date is in the metadata anyway, no data is lost. This is similar how replicaSets work

Closes #306 
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
