### PR TITLE
Print Schedule ref and status conditions in kubectl

### DIFF
--- a/api/v1alpha1/archive_types.go
+++ b/api/v1alpha1/archive_types.go
@@ -14,6 +14,7 @@ type ArchiveSpec struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Schedule Ref",type="string",JSONPath=`.metadata.ownerReferences[?(@.kind == "Schedule")].name`,description="Reference to Schedule"
+// +kubebuilder:printcolumn:name="Completion",type="string",JSONPath=`.status.conditions[?(@.type == "Completed")].reason`,description="Status of Completion"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Archive is the Schema for the archives API

--- a/api/v1alpha1/archive_types.go
+++ b/api/v1alpha1/archive_types.go
@@ -13,6 +13,8 @@ type ArchiveSpec struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Schedule Ref",type="string",JSONPath=`.metadata.ownerReferences[?(@.kind == "Schedule")].name`,description="Reference to Schedule"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Archive is the Schema for the archives API
 type Archive struct {

--- a/api/v1alpha1/backup_types.go
+++ b/api/v1alpha1/backup_types.go
@@ -42,6 +42,8 @@ type Env struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Schedule Ref",type="string",JSONPath=`.metadata.ownerReferences[?(@.kind == "Schedule")].name`,description="Reference to Schedule"
+// +kubebuilder:printcolumn:name="Completion",type="string",JSONPath=`.status.conditions[?(@.type == "Completed")].reason`,description="Status of Completion"
+// +kubebuilder:printcolumn:name="PreBackup",type="string",JSONPath=`.status.conditions[?(@.type == "PreBackupPodsReady")].reason`,description="Status of PreBackupPods"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Backup is the Schema for the backups API

--- a/api/v1alpha1/backup_types.go
+++ b/api/v1alpha1/backup_types.go
@@ -41,6 +41,8 @@ type Env struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Schedule Ref",type="string",JSONPath=`.metadata.ownerReferences[?(@.kind == "Schedule")].name`,description="Reference to Schedule"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Backup is the Schema for the backups API
 type Backup struct {

--- a/api/v1alpha1/check_types.go
+++ b/api/v1alpha1/check_types.go
@@ -22,6 +22,7 @@ type CheckSpec struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Schedule Ref",type="string",JSONPath=`.metadata.ownerReferences[?(@.kind == "Schedule")].name`,description="Reference to Schedule"
+// +kubebuilder:printcolumn:name="Completion",type="string",JSONPath=`.status.conditions[?(@.type == "Completed")].reason`,description="Status of Completion"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Check is the Schema for the checks API

--- a/api/v1alpha1/check_types.go
+++ b/api/v1alpha1/check_types.go
@@ -21,6 +21,8 @@ type CheckSpec struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Schedule Ref",type="string",JSONPath=`.metadata.ownerReferences[?(@.kind == "Schedule")].name`,description="Reference to Schedule"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Check is the Schema for the checks API
 type Check struct {

--- a/api/v1alpha1/prune_types.go
+++ b/api/v1alpha1/prune_types.go
@@ -44,6 +44,7 @@ type RetentionPolicy struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Schedule Ref",type="string",JSONPath=`.metadata.ownerReferences[?(@.kind == "Schedule")].name`,description="Reference to Schedule"
+// +kubebuilder:printcolumn:name="Completion",type="string",JSONPath=`.status.conditions[?(@.type == "Completed")].reason`,description="Status of Completion"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Prune is the Schema for the prunes API

--- a/api/v1alpha1/prune_types.go
+++ b/api/v1alpha1/prune_types.go
@@ -43,6 +43,8 @@ type RetentionPolicy struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Schedule Ref",type="string",JSONPath=`.metadata.ownerReferences[?(@.kind == "Schedule")].name`,description="Reference to Schedule"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Prune is the Schema for the prunes API
 type Prune struct {

--- a/api/v1alpha1/restore_types.go
+++ b/api/v1alpha1/restore_types.go
@@ -42,6 +42,8 @@ type FolderRestore struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Schedule Ref",type="string",JSONPath=`.metadata.ownerReferences[?(@.kind == "Schedule")].name`,description="Reference to Schedule"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Restore is the Schema for the restores API
 type Restore struct {

--- a/api/v1alpha1/restore_types.go
+++ b/api/v1alpha1/restore_types.go
@@ -43,6 +43,7 @@ type FolderRestore struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Schedule Ref",type="string",JSONPath=`.metadata.ownerReferences[?(@.kind == "Schedule")].name`,description="Reference to Schedule"
+// +kubebuilder:printcolumn:name="Completion",type="string",JSONPath=`.status.conditions[?(@.type == "Completed")].reason`,description="Status of Completion"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Restore is the Schema for the restores API

--- a/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_archives.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_archives.yaml
@@ -21,6 +21,10 @@ spec:
       jsonPath: .metadata.ownerReferences[?(@.kind == "Schedule")].name
       name: Schedule Ref
       type: string
+    - description: Status of Completion
+      jsonPath: .status.conditions[?(@.type == "Completed")].reason
+      name: Completion
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_archives.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_archives.yaml
@@ -16,7 +16,15 @@ spec:
     singular: archive
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Reference to Schedule
+      jsonPath: .metadata.ownerReferences[?(@.kind == "Schedule")].name
+      name: Schedule Ref
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Archive is the Schema for the archives API

--- a/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_backups.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_backups.yaml
@@ -16,7 +16,15 @@ spec:
     singular: backup
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Reference to Schedule
+      jsonPath: .metadata.ownerReferences[?(@.kind == "Schedule")].name
+      name: Schedule Ref
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Backup is the Schema for the backups API

--- a/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_backups.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_backups.yaml
@@ -21,6 +21,14 @@ spec:
       jsonPath: .metadata.ownerReferences[?(@.kind == "Schedule")].name
       name: Schedule Ref
       type: string
+    - description: Status of Completion
+      jsonPath: .status.conditions[?(@.type == "Completed")].reason
+      name: Completion
+      type: string
+    - description: Status of PreBackupPods
+      jsonPath: .status.conditions[?(@.type == "PreBackupPodsReady")].reason
+      name: PreBackup
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_checks.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_checks.yaml
@@ -21,6 +21,10 @@ spec:
       jsonPath: .metadata.ownerReferences[?(@.kind == "Schedule")].name
       name: Schedule Ref
       type: string
+    - description: Status of Completion
+      jsonPath: .status.conditions[?(@.type == "Completed")].reason
+      name: Completion
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_checks.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_checks.yaml
@@ -16,7 +16,15 @@ spec:
     singular: check
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Reference to Schedule
+      jsonPath: .metadata.ownerReferences[?(@.kind == "Schedule")].name
+      name: Schedule Ref
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Check is the Schema for the checks API

--- a/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_prunes.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_prunes.yaml
@@ -16,7 +16,15 @@ spec:
     singular: prune
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Reference to Schedule
+      jsonPath: .metadata.ownerReferences[?(@.kind == "Schedule")].name
+      name: Schedule Ref
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Prune is the Schema for the prunes API

--- a/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_prunes.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_prunes.yaml
@@ -21,6 +21,10 @@ spec:
       jsonPath: .metadata.ownerReferences[?(@.kind == "Schedule")].name
       name: Schedule Ref
       type: string
+    - description: Status of Completion
+      jsonPath: .status.conditions[?(@.type == "Completed")].reason
+      name: Completion
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_restores.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_restores.yaml
@@ -21,6 +21,10 @@ spec:
       jsonPath: .metadata.ownerReferences[?(@.kind == "Schedule")].name
       name: Schedule Ref
       type: string
+    - description: Status of Completion
+      jsonPath: .status.conditions[?(@.type == "Completed")].reason
+      name: Completion
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_restores.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/backup.appuio.ch_restores.yaml
@@ -16,7 +16,15 @@ spec:
     singular: restore
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Reference to Schedule
+      jsonPath: .metadata.ownerReferences[?(@.kind == "Schedule")].name
+      name: Schedule Ref
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Restore is the Schema for the restores API

--- a/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_archives.yaml
+++ b/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_archives.yaml
@@ -13,6 +13,10 @@ spec:
     description: Reference to Schedule
     name: Schedule Ref
     type: string
+  - JSONPath: .status.conditions[?(@.type == "Completed")].reason
+    description: Status of Completion
+    name: Completion
+    type: string
   - JSONPath: .metadata.creationTimestamp
     name: Age
     type: date

--- a/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_archives.yaml
+++ b/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_archives.yaml
@@ -8,6 +8,14 @@ metadata:
   creationTimestamp: null
   name: archives.backup.appuio.ch
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.ownerReferences[?(@.kind == "Schedule")].name
+    description: Reference to Schedule
+    name: Schedule Ref
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: backup.appuio.ch
   names:
     kind: Archive

--- a/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_backups.yaml
+++ b/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_backups.yaml
@@ -8,6 +8,14 @@ metadata:
   creationTimestamp: null
   name: backups.backup.appuio.ch
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.ownerReferences[?(@.kind == "Schedule")].name
+    description: Reference to Schedule
+    name: Schedule Ref
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: backup.appuio.ch
   names:
     kind: Backup

--- a/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_backups.yaml
+++ b/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_backups.yaml
@@ -13,6 +13,14 @@ spec:
     description: Reference to Schedule
     name: Schedule Ref
     type: string
+  - JSONPath: .status.conditions[?(@.type == "Completed")].reason
+    description: Status of Completion
+    name: Completion
+    type: string
+  - JSONPath: .status.conditions[?(@.type == "PreBackupPodsReady")].reason
+    description: Status of PreBackupPods
+    name: PreBackup
+    type: string
   - JSONPath: .metadata.creationTimestamp
     name: Age
     type: date

--- a/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_checks.yaml
+++ b/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_checks.yaml
@@ -13,6 +13,10 @@ spec:
     description: Reference to Schedule
     name: Schedule Ref
     type: string
+  - JSONPath: .status.conditions[?(@.type == "Completed")].reason
+    description: Status of Completion
+    name: Completion
+    type: string
   - JSONPath: .metadata.creationTimestamp
     name: Age
     type: date

--- a/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_checks.yaml
+++ b/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_checks.yaml
@@ -8,6 +8,14 @@ metadata:
   creationTimestamp: null
   name: checks.backup.appuio.ch
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.ownerReferences[?(@.kind == "Schedule")].name
+    description: Reference to Schedule
+    name: Schedule Ref
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: backup.appuio.ch
   names:
     kind: Check

--- a/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_prunes.yaml
+++ b/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_prunes.yaml
@@ -13,6 +13,10 @@ spec:
     description: Reference to Schedule
     name: Schedule Ref
     type: string
+  - JSONPath: .status.conditions[?(@.type == "Completed")].reason
+    description: Status of Completion
+    name: Completion
+    type: string
   - JSONPath: .metadata.creationTimestamp
     name: Age
     type: date

--- a/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_prunes.yaml
+++ b/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_prunes.yaml
@@ -8,6 +8,14 @@ metadata:
   creationTimestamp: null
   name: prunes.backup.appuio.ch
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.ownerReferences[?(@.kind == "Schedule")].name
+    description: Reference to Schedule
+    name: Schedule Ref
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: backup.appuio.ch
   names:
     kind: Prune

--- a/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_restores.yaml
+++ b/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_restores.yaml
@@ -13,6 +13,10 @@ spec:
     description: Reference to Schedule
     name: Schedule Ref
     type: string
+  - JSONPath: .status.conditions[?(@.type == "Completed")].reason
+    description: Status of Completion
+    name: Completion
+    type: string
   - JSONPath: .metadata.creationTimestamp
     name: Age
     type: date

--- a/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_restores.yaml
+++ b/config/crd/apiextensions.k8s.io/v1beta1/backup.appuio.ch_restores.yaml
@@ -8,6 +8,14 @@ metadata:
   creationTimestamp: null
   name: restores.backup.appuio.ch
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.ownerReferences[?(@.kind == "Schedule")].name
+    description: Reference to Schedule
+    name: Schedule Ref
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: backup.appuio.ch
   names:
     kind: Restore

--- a/config/samples/secrets.yaml
+++ b/config/samples/secrets.yaml
@@ -3,14 +3,14 @@ kind: Secret
 metadata:
   name: backup-credentials
 type: Opaque
-data:
-  username: OFUwVUROWVBOVURUVVMxTElBRjM=
-  password: aXAzY2Rya1hjSG1INFM3aWY3ZXJLUE5veERuMjdWMHZyZzZDSEhlbQ==
+stringData:
+  username: 8U0UDNYPNUDTUS1LIAF3
+  password: ip3cdrkXcHmH4S7if7erKPNoxDn27V0vrg6CHHem
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: backup-repo
 type: Opaque
-data:
-  password: YXNkZg==
+stringData:
+  password: asdf

--- a/docs/modules/ROOT/pages/how-tos/check-status.adoc
+++ b/docs/modules/ROOT/pages/how-tos/check-status.adoc
@@ -4,6 +4,27 @@
 
 The Kubernetes objects of K8up try to convey enough status information to understand common error conditions.
 All objects maintain the Status property and most of them provide additional information through Conditions.
+This allows to wait for certain steps in the process.
+
+This will wait until the backup has started:
+[example]
+kubectl wait --for condition=progressing backup/demo-backup
+
+This will wait until the backup was completed.
+The `Reason` of the condition tells you whether it was successful or not:
+[example]
+kubectl wait --for condition=completed backup/demo-backup`
+
+.Sample output when querying for backups
+[source,bash]
+....
+$ kubectl get backup
+NAME                         SCHEDULE REF    COMPLETION   PREBACKUP              AGE
+demo-backup                                  Succeeded    NoPreBackupPodsFound   3m20s
+schedule-test-backup-b6bxz   schedule-test                NoPreBackupPodsFound   20s
+schedule-test-backup-sj5rt   schedule-test                NoPreBackupPodsFound   80s
+schedule-test-backup-whnkl   schedule-test   Failed       NoPreBackupPodsFound   2m20s
+....
 
 === Status of Backups in particular
 
@@ -32,33 +53,31 @@ Spec:
   # [clipped for brevity]
 Status:
   Conditions:
-    Last Transition Time:  2020-13-32T25:61:61Z
+    Last Transition Time:  2020-13-32T25:71:61Z
+    Message:               Deleted 1 resources
+    Reason:                Succeeded
     Status:                True
-    Type:                  CleanupSucceeded
+    Type:                  Scrubbed
     Last Transition Time:  2020-13-32T25:61:61Z
     Message:               the job 'default/demo-backup' was created
+    Reason:                Ready
     Status:                True
-    Type:                  JobCreated
-    Last Transition Time:  2020-13-32T25:61:61Z
+    Type:                  Ready
+    Last Transition Time:  2020-13-32T25:71:61Z
+    Message:               the job 'default/demo-backup' ended
+    Reason:                Finished
+    Status:                False
+    Type:                  Progressing
+    Last Transition Time:  2020-13-32T25:71:61Z
     Message:               the job 'default/demo-backup' ended successfully
+    Reason:                Succeeded
     Status:                True
-    Type:                  JobSucceeded
+    Type:                  Completed
     Last Transition Time:  2020-13-32T25:61:61Z
     Message:               no container definitions found
-    Status:                False
-    Type:                  PreBackupPodsAvailable
-    Last Transition Time:  2020-13-32T25:61:61Z
+    Reason:                NoPreBackupPodsFound
     Status:                True
-    Type:                  PreBackupPodsRemoved
-    Last Transition Time:  2020-13-32T25:61:61Z
-    Status:                True
-    Type:                  RoleBindingReady
-    Last Transition Time:  2020-13-32T25:61:61Z
-    Status:                True
-    Type:                  RoleReady
-    Last Transition Time:  2020-13-32T25:61:61Z
-    Status:                True
-    Type:                  ServiceAccountReady
+    Type:                  PreBackupPodsReady
   Started:                 true
 Events:                    <none>
 

--- a/executor/generic.go
+++ b/executor/generic.go
@@ -139,7 +139,7 @@ func (g *generic) RegisterJobSucceededConditionCallback() {
 				event.Job.Namespace, event.Job.Name)
 		case observer.Failed:
 			g.SetFinished(event.Job.Namespace, event.Job.Name)
-			g.SetConditionFalseWithMessage(k8upv1alpha1.ConditionCompleted,
+			g.SetConditionTrueWithMessage(k8upv1alpha1.ConditionCompleted,
 				k8upv1alpha1.ReasonFailed,
 				"the job '%v/%v' failed, please check its log for details",
 				event.Job.Namespace, event.Job.Name)


### PR DESCRIPTION
## Summary

- Displays the name of the schedule if a job got created by a schedule, otherwise it's empty
- Displays the reason for a completion condition if there is any
- For Backups, it also displays the status condition of prebackups

```console
$ k get backup
NAME                         SCHEDULE REF    COMPLETION   PREBACKUP              AGE
schedule-test-backup-4fpbd   schedule-test   Failed       NoPreBackupPodsFound   3m20s
schedule-test-backup-b6bxz   schedule-test                NoPreBackupPodsFound   20s
schedule-test-backup-sj5rt   schedule-test                NoPreBackupPodsFound   80s
schedule-test-backup-whnkl   schedule-test   Failed       NoPreBackupPodsFound   2m20s
```

## Checklist
- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.
- [x] ~Update tests.~
- [x] ~Link this PR to related issues.~
