### PR TITLE
Fix "sha1sum command is not found" in e2e-tests on macOS

### DIFF
--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -18,7 +18,8 @@ KIND_KUBECONFIG ?= $(TESTBIN_DIR)/kind-kubeconfig-$(KIND_NODE_VERSION)
 KIND_CLUSTER ?= k8up-$(KIND_NODE_VERSION)
 KIND_KUBECTL_ARGS ?= --validate=true
 
-E2E_TAG ?= e2e_$(shell sha1sum $(BIN_FILENAME) | cut -b-8)
+SHASUM ?= $(shell command -v sha1sum > /dev/null && echo "sha1sum" || echo "shasum -a1")
+E2E_TAG ?= e2e_$(shell $(SHASUM) $(BIN_FILENAME) | cut -b-8)
 E2E_REPO ?= local.dev/k8up/e2e
 E2E_IMG = $(E2E_REPO):$(E2E_TAG)
 


### PR DESCRIPTION
## Summary

Fixes Issue #339 – "e2e-test: sha1sum command is not found on macOS"
While running the e2e-test on macOS, the e2e images tag `E2E_TAG` is not calculated properly as the `sha1sum` command is not found on macOS.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Link this PR to related issues.
