### PR TITLE
Speed up `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 all: build ## Invokes the build target
 
 .PHONY: test
-test: fmt vet ## Run tests
+test: ## Run tests
 	go test ./... -coverprofile cover.out
 
 # See https://storage.googleapis.com/kubebuilder-tools/ for list of supported K8s versions


### PR DESCRIPTION
## Summary

The target `make lint` depends on `make vet fmt`.
The target `make test` also depends on `make vet fmt`, which is redundant in that case.
To speed up running the unit tests, `make vet fmt` have been removed as dependencies from `make test`.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
