### PR TITLE
Use '%w' syntax in fmt.Errorf

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -83,16 +83,16 @@ func NewDefaultConfig() *Configuration {
 
 func (c Configuration) ValidateSyntax() error {
 	if _, err := resource.ParseQuantity(c.GlobalMemoryResourceRequest); err != nil && c.GlobalMemoryResourceRequest != "" {
-		return fmt.Errorf("cannot parse global memory request: %v", err)
+		return fmt.Errorf("cannot parse global memory request: %w", err)
 	}
 	if _, err := resource.ParseQuantity(c.GlobalMemoryResourceLimit); err != nil && c.GlobalMemoryResourceLimit != "" {
-		return fmt.Errorf("cannot parse global memory limit: %v", err)
+		return fmt.Errorf("cannot parse global memory limit: %w", err)
 	}
 	if _, err := resource.ParseQuantity(c.GlobalCPUResourceRequest); err != nil && c.GlobalCPUResourceRequest != "" {
-		return fmt.Errorf("cannot parse global CPU request: %v", err)
+		return fmt.Errorf("cannot parse global CPU request: %w", err)
 	}
 	if _, err := resource.ParseQuantity(c.GlobalCPUResourceLimit); err != nil && c.GlobalCPUResourceLimit != "" {
-		return fmt.Errorf("cannot parse global CPU limit: %v", err)
+		return fmt.Errorf("cannot parse global CPU limit: %w", err)
 	}
 	if c.OperatorNamespace == "" {
 		return fmt.Errorf("operator namespace cannot be empty")


### PR DESCRIPTION
## Summary

I've quickly scanned through all invocations of `fmt.Errorf` to ensure that they use the `'%w'` syntax to wrap the respective error.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [ ] ~Update the documentation.~
- [ ] ~Update tests.~
- [ ] ~Link this PR to related issues.~

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
