### PR TITLE
Explain backupcommand for pods with same owner reference

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/application-aware-backups.adoc
+++ b/docs/modules/ROOT/pages/how-tos/application-aware-backups.adoc
@@ -18,6 +18,7 @@ template:
 ----
 
 With this annotation the Operator will trigger that command inside the the container and capture the stdout to a backup.
+The command is only executed on one Pod, if there are multiple Pods with the same owner reference (e.g. Deployments, Statefulsets etc).
 
 Tested with:
 


### PR DESCRIPTION
## Summary

Documentation update for How-to-guides / Application-Aware Backups explaining the behavior with multiple pods (e.g. Deployments, Statefulsets)


## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.