### PR TITLE
Ensure linter checks for generated code too

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,4 +23,4 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Run linters
-      run: make lint
+      run: make generate lint

--- a/config/crd/apiextensions.k8s.io/v1/base/backup.appuio.ch_effectiveschedules.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/base/backup.appuio.ch_effectiveschedules.yaml
@@ -18,11 +18,11 @@ spec:
   versions:
   - additionalPrinterColumns:
     - description: Schedule Namespace
-      jsonPath: .spec.effectiveSchedules[0].namespace
+      jsonPath: .spec.scheduleRefs[0].namespace
       name: Schedule Namespace
       type: string
     - description: Schedule Name
-      jsonPath: .spec.effectiveSchedules[0].name
+      jsonPath: .spec.scheduleRefs[0].name
       name: Schedule Name
       type: string
     - description: Generated Schedule

--- a/config/crd/apiextensions.k8s.io/v1beta1/base/backup.appuio.ch_effectiveschedules.yaml
+++ b/config/crd/apiextensions.k8s.io/v1beta1/base/backup.appuio.ch_effectiveschedules.yaml
@@ -9,11 +9,11 @@ metadata:
   name: effectiveschedules.backup.appuio.ch
 spec:
   additionalPrinterColumns:
-  - JSONPath: .spec.effectiveSchedules[0].namespace
+  - JSONPath: .spec.scheduleRefs[0].namespace
     description: Schedule Namespace
     name: Schedule Namespace
     type: string
-  - JSONPath: .spec.effectiveSchedules[0].name
+  - JSONPath: .spec.scheduleRefs[0].name
     description: Schedule Name
     name: Schedule Name
     type: string


### PR DESCRIPTION
## Summary

* `lint` when executed from GH action also checks if generated code is up-to-date.
* This prevents doing changes but forgetting to run `make generate`

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
