### PR TITLE
Change logging key to avoid clash

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -104,7 +104,7 @@ func (s *Scheduler) addSchedules(jobs JobList, namespacedName types.NamespacedNa
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	for _, schedulableJob := range jobs.Jobs {
-		config.Log.Info("registering schedule for", "type", schedulableJob.JobType, "schedule", schedulableJob.Schedule)
+		config.Log.Info("registering schedule for", "type", schedulableJob.JobType, "cron", schedulableJob.Schedule)
 		err := s.addSchedule(schedulableJob, namespacedName, s.getScheduleCallback(config, namespacedName, schedulableJob))
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary

* Changes logging key for cron schedule: `2021-02-08T17:56:46.821+0100	INFO	controllers.Schedule	registering schedule for	{"schedule": "syn-backup-cluster-objects/k8s-objects", "type": "check", "schedule": "30 3 * * *"}` (schedule was duplicated, now it's `cron`)

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
