### PR TITLE
Fix change of random schedule not being applied

### DIFF
--- a/api/v1alpha1/effectiveschedule_types.go
+++ b/api/v1alpha1/effectiveschedule_types.go
@@ -33,6 +33,8 @@ type (
 	EffectiveScheduleSpec struct {
 		// GeneratedSchedule is the effective schedule that is added to Cron
 		GeneratedSchedule ScheduleDefinition `json:"generatedSchedule,omitempty"`
+		// OriginalSchedule is the original user-defined schedule definition in the Schedule object.
+		OriginalSchedule ScheduleDefinition `json:"originalSchedule,omitempty"`
 		// JobType defines to which job type this schedule applies
 		JobType JobType `json:"jobType,omitempty"`
 		// ScheduleRefs holds a list of schedules for which the generated schedule applies to.
@@ -46,6 +48,16 @@ type (
 		Namespace string `json:"namespace,omitempty"`
 	}
 )
+
+// AddScheduleRef adds the given newRef to the existing ScheduleRefs if not already existing.
+func (in *EffectiveScheduleSpec) AddScheduleRef(newRef ScheduleRef) {
+	for _, ref := range in.ScheduleRefs {
+		if ref.Name == newRef.Name && ref.Namespace == newRef.Namespace {
+			return
+		}
+	}
+	in.ScheduleRefs = append(in.ScheduleRefs, newRef)
+}
 
 func init() {
 	SchemeBuilder.Register(&EffectiveSchedule{}, &EffectiveScheduleList{})

--- a/config/crd/apiextensions.k8s.io/v1/base/backup.appuio.ch_effectiveschedules.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/base/backup.appuio.ch_effectiveschedules.yaml
@@ -58,6 +58,9 @@ spec:
               jobType:
                 description: JobType defines to which job type this schedule applies
                 type: string
+              originalSchedule:
+                description: OriginalSchedule is the original user-defined schedule definition in the Schedule object.
+                type: string
               scheduleRefs:
                 description: ScheduleRefs holds a list of schedules for which the generated schedule applies to. The list may omit entries that aren't generated from smart schedules.
                 items:

--- a/config/crd/apiextensions.k8s.io/v1beta1/base/backup.appuio.ch_effectiveschedules.yaml
+++ b/config/crd/apiextensions.k8s.io/v1beta1/base/backup.appuio.ch_effectiveschedules.yaml
@@ -57,6 +57,9 @@ spec:
             jobType:
               description: JobType defines to which job type this schedule applies
               type: string
+            originalSchedule:
+              description: OriginalSchedule is the original user-defined schedule definition in the Schedule object.
+              type: string
             scheduleRefs:
               description: ScheduleRefs holds a list of schedules for which the generated schedule applies to. The list may omit entries that aren't generated from smart schedules.
               items:

--- a/controllers/schedule_it_test.go
+++ b/controllers/schedule_it_test.go
@@ -33,7 +33,7 @@ func (ts *ScheduleControllerTestSuite) BeforeTest(suiteName, testName string) {
 	cfg.Config.OperatorNamespace = ts.NS
 	ts.reconciler = &controllers.ScheduleReconciler{
 		Client: ts.Client,
-		Log:    ts.Logger.WithName(suiteName),
+		Log:    ts.Logger.WithName(suiteName + "_" + testName),
 		Scheme: ts.Scheme,
 	}
 }
@@ -43,7 +43,7 @@ func (ts *ScheduleControllerTestSuite) Test_GivenScheduleWithRandomSchedules_Whe
 
 	ts.whenReconciling(ts.givenSchedule)
 
-	ts.thenAssertEffectiveScheduleExists(ts.givenSchedule.Name)
+	ts.thenAssertEffectiveScheduleExists(ts.givenSchedule.Name, handler.ScheduleDailyRandom)
 
 	actualSchedule := &k8upv1alpha1.Schedule{}
 	ts.FetchResource(k8upv1alpha1.GetNamespacedName(ts.givenSchedule), actualSchedule)
@@ -98,6 +98,17 @@ func (ts *ScheduleControllerTestSuite) Test_GivenEffectiveScheduleWithRandomSche
 
 	actualESList := ts.whenListEffectiveSchedules()
 	ts.Assert().Len(actualESList, 0)
+}
+
+func (ts *ScheduleControllerTestSuite) Test_GivenEffectiveScheduleWithRandomSchedules_WhenChangingSchedule_ThenMakeNewEffectiveSchedule() {
+	ts.givenScheduleResource(handler.ScheduleDailyRandom)
+	ts.givenEffectiveScheduleResource(ts.givenSchedule.Name)
+
+	ts.whenReconciling(ts.givenSchedule)
+
+	actualESList := ts.whenListEffectiveSchedules()
+	ts.Assert().Len(actualESList, 1)
+	ts.thenAssertEffectiveScheduleExists(ts.givenSchedule.Name, handler.ScheduleDailyRandom)
 }
 
 func (ts *ScheduleControllerTestSuite) whenReconciling(givenSchedule *k8upv1alpha1.Schedule) {

--- a/controllers/schedule_it_utils_test.go
+++ b/controllers/schedule_it_utils_test.go
@@ -7,6 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	k8upv1alpha1 "github.com/vshn/k8up/api/v1alpha1"
+	"github.com/vshn/k8up/handler"
 )
 
 func (ts *ScheduleControllerTestSuite) givenScheduleResource(schedule k8upv1alpha1.ScheduleDefinition) {
@@ -24,6 +25,7 @@ func (ts *ScheduleControllerTestSuite) givenEffectiveScheduleResource(scheduleNa
 			ScheduleRefs: []k8upv1alpha1.ScheduleRef{
 				{Name: scheduleName, Namespace: ts.NS},
 			},
+			OriginalSchedule: handler.ScheduleHourlyRandom,
 		},
 	}
 	ts.EnsureResources(&givenSchedule)
@@ -43,13 +45,14 @@ func (ts *ScheduleControllerTestSuite) newScheduleSpec(name string, schedule k8u
 	}
 }
 
-func (ts *ScheduleControllerTestSuite) thenAssertEffectiveScheduleExists(expectedScheduleName string) {
+func (ts *ScheduleControllerTestSuite) thenAssertEffectiveScheduleExists(expectedScheduleName string, originalSchedule k8upv1alpha1.ScheduleDefinition) {
 	list := ts.whenListEffectiveSchedules()
 	ts.Require().NotEmpty(list)
 	spec := list[0].Spec
-	ts.Require().NotEmpty(spec.ScheduleRefs)
+	ts.Require().Len(spec.ScheduleRefs, 1)
 	ref := spec.ScheduleRefs[0]
 	ts.Assert().Equal(expectedScheduleName, ref.Name)
+	ts.Assert().Equal(spec.OriginalSchedule, originalSchedule)
 	ts.Assert().Equal(ts.NS, ref.Namespace)
 	ts.Assert().False(spec.GeneratedSchedule.IsRandom())
 }

--- a/docs/modules/ROOT/pages/references/api-reference.adoc
+++ b/docs/modules/ROOT/pages/references/api-reference.adoc
@@ -376,6 +376,7 @@ EffectiveScheduleSpec defines the desired state of EffectiveSchedule
 |===
 | Field | Description
 | *`generatedSchedule`* __xref:{anchor_prefix}-github-com-vshn-k8up-api-v1alpha1-scheduledefinition[$$ScheduleDefinition$$]__ | GeneratedSchedule is the effective schedule that is added to Cron
+| *`originalSchedule`* __xref:{anchor_prefix}-github-com-vshn-k8up-api-v1alpha1-scheduledefinition[$$ScheduleDefinition$$]__ | OriginalSchedule is the original user-defined schedule definition in the Schedule object.
 | *`jobType`* __JobType__ | JobType defines to which job type this schedule applies
 | *`scheduleRefs`* __xref:{anchor_prefix}-github-com-vshn-k8up-api-v1alpha1-scheduleref[$$ScheduleRef$$] array__ | ScheduleRefs holds a list of schedules for which the generated schedule applies to. The list may omit entries that aren't generated from smart schedules.
 |===

--- a/handler/effectiveschedule_test.go
+++ b/handler/effectiveschedule_test.go
@@ -42,6 +42,7 @@ func TestScheduleHandler_findExistingSchedule(t *testing.T) {
 						ScheduleRefs: []k8upv1alpha1.ScheduleRef{
 							{Name: "schedule", Namespace: "default"},
 						},
+						OriginalSchedule: ScheduleDailyRandom,
 					},
 				},
 			},
@@ -61,7 +62,7 @@ func TestScheduleHandler_findExistingSchedule(t *testing.T) {
 				Config:             job.Config{Log: zap.New(zap.UseDevMode(true))},
 				effectiveSchedules: tt.givenEffectiveSchedules,
 			}
-			schedule, found := s.findExistingSchedule(tt.givenJobType)
+			schedule, found := s.findExistingSchedule(tt.givenJobType, ScheduleDailyRandom)
 
 			assert.Equal(t, tt.expectedSchedule, schedule)
 			assert.Equal(t, tt.expectFind, found)


### PR DESCRIPTION
## Summary

* Adds new field `spec.originalSchedule` to EffectiveSchedule
* Upon changing the random schedule, it **updates** the existing EffectiveSchedule with a new randomized schedule. This is contrary to the expected behaviour in #354 , but it was easier to implement without changing more of the structure. This should be fine as long as we don't have deduplication, which needs a new behaviour in that case anyway.

Closes #354 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] ~Update the documentation.~
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
