### PR TITLE
Fix loading of Operator environment variables

### DIFF
--- a/main.go
+++ b/main.go
@@ -136,7 +136,7 @@ func loadEnvironmentVariables() {
 	prefix := "BACKUP_"
 	// Load environment variables
 	err := koanfInstance.Load(env.Provider(prefix, ".", func(s string) string {
-		s = strings.TrimLeft(s, prefix)
+		s = strings.TrimPrefix(s, prefix)
 		s = strings.Replace(strings.ToLower(s), "_", "-", -1)
 		return s
 	}), nil)

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -141,14 +142,14 @@ func loadEnvironmentVariables() {
 		return s
 	}), nil)
 	if err != nil {
-		setupLog.Error(err, "could not load environment variables")
+		_, _ = fmt.Fprintf(os.Stderr, "could not load environment variables: %v\n", err)
 	}
 
 	if err := koanfInstance.UnmarshalWithConf("", &cfg.Config, koanf.UnmarshalConf{Tag: "koanf", FlatPaths: true}); err != nil {
-		setupLog.Error(err, "could not merge defaults with settings from environment variables")
+		_, _ = fmt.Fprintf(os.Stderr, "could not merge defaults with settings from environment variables: %v\n", err)
 	}
 	if err := cfg.Config.ValidateSyntax(); err != nil {
-		setupLog.Error(err, "settings invalid")
+		_, _ = fmt.Fprintf(os.Stderr, "settings invalid: %v\n", err)
 		os.Exit(2)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vshn/k8up/cfg"
+)
+
+func Test_loadEnvironmentVariables(t *testing.T) {
+	tests := map[string]struct {
+		givenKey     string
+		givenValue   string
+		assertConfig func(t *testing.T, c *cfg.Configuration)
+	}{
+		"GivenStringVariable_WhenLoading_ThenParseStringVar": {
+			givenKey:   "BACKUP_PROMURL",
+			givenValue: "https://prometheus:9090/metrics",
+			assertConfig: func(t *testing.T, c *cfg.Configuration) {
+				assert.Equal(t, "https://prometheus:9090/metrics", c.PromURL)
+			},
+		},
+		"GivenNumericEnvironmentVariable_WhenLoading_ThenParseIntVar": {
+			givenKey:   "BACKUP_GLOBALKEEPJOBS",
+			givenValue: "2",
+			assertConfig: func(t *testing.T, c *cfg.Configuration) {
+				assert.Equal(t, 2, c.GlobalKeepJobs)
+			},
+		},
+		"GivenBooleanEnvironmentVariable_WhenLoading_ThenParseBoolVar": {
+			givenKey:   "BACKUP_ENABLE_LEADER_ELECTION",
+			givenValue: "false",
+			assertConfig: func(t *testing.T, c *cfg.Configuration) {
+				assert.True(t, cfg.NewDefaultConfig().EnableLeaderElection) // To ensure it's not asserting the default
+				assert.False(t, c.EnableLeaderElection)
+			},
+		},
+	}
+	cfg.Config.OperatorNamespace = "not-part-of-this-test"
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.NoError(t, os.Setenv(tt.givenKey, tt.givenValue))
+			loadEnvironmentVariables()
+			tt.assertConfig(t, cfg.Config)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

* Fixes #357 , some prefix handling was broken with "TrimLeft" function.
  (It previously considered the `P` from `PROMURL` also to be trimmed, so it trimmed `BACKUP_P`, resulting in `ROMURL`. Koanf simply did not know where to put it in `cfg.Config`).
* Also prints config loading errors to stderr in `loadEnvironmentVariables`, since the `setupLog` isn't initiated at this time. K8up would just exit with error code without logging anything at all.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
