### PR TITLE
Replace 'Succeeded' reason in PreBackupReady condition with 'Ready'

### DIFF
--- a/docs/modules/ROOT/pages/references/status.adoc
+++ b/docs/modules/ROOT/pages/references/status.adoc
@@ -76,7 +76,7 @@ Each condition also contains a human-readable message that describes the status 
 | `PreBackupPod` definitions could not be retrieved from Kubernetes
 
 | Waiting
-| The `Backup` is waiting for `PreBackupPods` to finish.
+| The `Backup` is waiting for `PreBackupPod` deployments to become ready.
 
 | CreationFailed
 | `PreBackupPod` deployments could not be created.
@@ -84,7 +84,7 @@ Each condition also contains a human-readable message that describes the status 
 | Failed
 | `PreBackupPod` deployments failed with an unknown error.
 
-| Succeeded
-| `PreBackupPod` deployments successfully finished.
+| Ready
+| `PreBackupPod` deployments ready.
 
 |===

--- a/prebackup/prebackup.go
+++ b/prebackup/prebackup.go
@@ -135,7 +135,7 @@ func (p *PreBackup) startAllAndWaitForReady(deployments []appsv1.Deployment) err
 		}
 	}
 
-	p.SetConditionTrue(ConditionPreBackupPodsReady, k8upv1alpha1.ReasonSucceeded)
+	p.SetConditionTrue(ConditionPreBackupPodsReady, k8upv1alpha1.ReasonReady)
 	return nil
 }
 
@@ -174,7 +174,7 @@ func (p *PreBackup) startOneAndWaitForReady(deployment appsv1.Deployment, client
 		}
 		if ready {
 			p.Log.V(2).Info("pre backup pod already in ready state", "deployment", fmt.Sprintf("%s/%s", deployment.Namespace, deployment.Name), "event type")
-			p.SetConditionTrue(ConditionPreBackupPodsReady, k8upv1alpha1.ReasonSucceeded)
+			p.SetConditionTrue(ConditionPreBackupPodsReady, k8upv1alpha1.ReasonReady)
 			return nil
 		}
 	}
@@ -343,5 +343,5 @@ func (p *PreBackup) Stop() {
 		}
 	}
 
-	p.SetConditionTrue(ConditionPreBackupPodsReady, k8upv1alpha1.ReasonSucceeded)
+	p.SetConditionTrue(ConditionPreBackupPodsReady, k8upv1alpha1.ReasonReady)
 }


### PR DESCRIPTION
## Summary

Marking PreBackups as "Succeeded" is not exactly the intention we wanted to bring.
By the current design, marking a PreBackup deployment as 'ready' fits closer the workflow.

However, this should be considered breaking change in the API. But since it's a reason in a condition, I doubt it justifies a major version bump, since v1 is just a few weeks old, not many would be using the Reason field in a condition for programmatic API access.

Part of a fix for #370 , but made into its own PR to keep a separate changelog entry

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.
