### PR TITLE
Pin wrestic image for e2e-tests

### DIFF
--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -32,5 +32,6 @@ KUSTOMIZE ?= go run sigs.k8s.io/kustomize/kustomize/v3
 # Image URL to use all building/pushing image targets
 DOCKER_IMG ?= docker.io/vshn/k8up:$(IMG_TAG)
 QUAY_IMG ?= quay.io/vshn/k8up:$(IMG_TAG)
+WRESTIC_IMG ?= quay.io/vshn/wrestic:v0.1.9
 
 testbin_created = $(TESTBIN_DIR)/.created

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -26,6 +26,7 @@ bats_args ?=
 .PHONY: test
 test: export KUBECONFIG = $(KIND_KUBECONFIG)
 test: export E2E_IMAGE = $(E2E_IMG)
+test: export WRESTIC_IMAGE = $(WRESTIC_IMG)
 test: setup kind-e2e-image ## Run the E2E tests
 	@$(bats) . $(bats_args)
 

--- a/e2e/lib/k8up.bash
+++ b/e2e/lib/k8up.bash
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-export WRESTIC_IMAGE=${WRESTIC_IMAGE-quay.io/vshn/wrestic}
-
 errcho() {
 	>&2 echo "${@}"
 }
@@ -36,7 +34,7 @@ restic() {
 		--attach \
 		--restart Never \
 		--namespace "${DETIK_CLIENT_NAMESPACE-"k8up-system"}" \
-		--image "${WRESTIC_IMAGE-quay.io/vshn/wrestic}" \
+		--image "${WRESTIC_IMAGE}" \
 		--env "AWS_ACCESS_KEY_ID=myaccesskey" \
 		--env "AWS_SECRET_KEY=mysecretkey" \
 		--env "RESTIC_PASSWORD=myreposecret" \


### PR DESCRIPTION
## Summary

The latest v0.2.x suffers a startup bug. Pin wrestic for e2e-tests until its fixed or generally until wrestic is integrated into K8up. So that e2e-tests pass

see https://github.com/vshn/wrestic/issues/70

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
