### PR TITLE
Update vshn/wrestic image to v0.2.2 in e2e-tests

### DIFF
--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -34,6 +34,6 @@ KUSTOMIZE ?= go run sigs.k8s.io/kustomize/kustomize/v3
 # Image URL to use all building/pushing image targets
 DOCKER_IMG ?= docker.io/vshn/k8up:$(IMG_TAG)
 QUAY_IMG ?= quay.io/vshn/k8up:$(IMG_TAG)
-WRESTIC_IMG ?= quay.io/vshn/wrestic:v0.1.9
+WRESTIC_IMG ?= quay.io/vshn/wrestic:v0.2.2
 
 testbin_created = $(TESTBIN_DIR)/.created


### PR DESCRIPTION
## Summary

Pin vshn/wrestic image to v0.2.2 in e2e-tests

## Checklist


- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update tests.
