### PR TITLE
Remove preserveUnknownFields in v1 PreBackupPod CRD

### DIFF
--- a/config/crd/apiextensions.k8s.io/v1/base/backup.appuio.ch_prebackuppods.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/base/backup.appuio.ch_prebackuppods.yaml
@@ -8,7 +8,6 @@ metadata:
   creationTimestamp: null
   name: prebackuppods.backup.appuio.ch
 spec:
-  preserveUnknownFields: false
   group: backup.appuio.ch
   names:
     kind: PreBackupPod

--- a/generate.go
+++ b/generate.go
@@ -19,7 +19,7 @@ import (
 	"os"
 )
 
-var patchFiles = []string{"v1beta1/base/backup.appuio.ch_prebackuppods.yaml", "v1/base/backup.appuio.ch_prebackuppods.yaml"}
+var patchFiles = []string{"v1beta1/base/backup.appuio.ch_prebackuppods.yaml"}
 
 // controller-gen 0.3 creates CRDs with apiextensions.k8s.io/v1beta1, but some generated properties aren't valid for that version
 // in K8s 1.18+. We would have to switch to apiextensions.k8s.io/v1, but that would make the CRD incompatible with OpenShift 3.11.


### PR DESCRIPTION
## Summary

* Remove deprecated preserveUnknownFields from v1 PreBackupPod CRD. It's being removed by the API server anyway (doesn't show up in the YAML after applying).
* Fixes #405 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
