### PR TITLE
Fix missing cleanup of PreBackupPod deployments

### DIFF
--- a/config/samples/k8up_v1alpha1_prebackuppod.yaml
+++ b/config/samples/k8up_v1alpha1_prebackuppod.yaml
@@ -22,7 +22,7 @@ spec:
               value: mariadb.example.com
           image: mariadb
           command:
-            - 'sleep'
-            - '9999999'
+            - sleep
+            - infinity
           imagePullPolicy: Always
           name: mysqldump

--- a/controllers/envsuite_test.go
+++ b/controllers/envsuite_test.go
@@ -233,7 +233,7 @@ func (ts *EnvTestSuite) SanitizeNameForNS(name string) string {
 }
 
 // IsResourceExisting tries to fetch the given resource and returns true if it exists.
-// It will consider still-existing object with a deletion timestamp as not existing.
+// It will consider still-existing object with a deletion timestamp as non-existing.
 // Any other errors will fail the test.
 func (ts *EnvTestSuite) IsResourceExisting(ctx context.Context, obj client.Object) bool {
 	err := ts.Client.Get(ctx, k8upv1a1.MapToNamespacedName(obj), obj)

--- a/docs/modules/ROOT/pages/references/object-specifications.adoc
+++ b/docs/modules/ROOT/pages/references/object-specifications.adoc
@@ -412,8 +412,8 @@ spec:
               value: mariadb.example.com
           image: mariadb
           command:
-            - 'sleep'
-            - '9999999'
+            - sleep
+            - infinity
           imagePullPolicy: Always
           name: mysqldump
 ----

--- a/executor/prebackup.go
+++ b/executor/prebackup.go
@@ -92,7 +92,7 @@ func (b *BackupExecutor) StopPreBackupDeployments() {
 		return
 	}
 
-	deployments := b.generateDeployments(nil)
+	deployments := b.generateDeployments(templates.Items)
 	for _, deployment := range deployments {
 		// Avoid exportloopref
 		deployment := deployment


### PR DESCRIPTION
## Summary

Because of a tiny oversight during development, the method that should cleanup the deployments of completed PreBackupPods got invoked with `nil` instead of the list of deployments.

Fixes https://github.com/vshn/k8up/issues/413

I also replaced `sleep '9999999'` with `sleep infinity` in the documentation and examples, because that is the proper way to tell a shell to do nothing forever, i.e. to wait until the pre-backup command was executed and it is eventually told to terminate. This was also performed by the user who reported the bug.

Trivia: As often, implementing the bugfix was quite trivial, once understood where the problem lies. But implementing a test to prevent that scenario in the future took quite some time.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [ ] Update the documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
