### PR TITLE
WIP: Make the watch namespace configurable

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -70,6 +70,9 @@ type Configuration struct {
 	EnableLeaderElection bool   `koanf:"enable-leader-election"`
 	LogLevel             string `koanf:"log-level"`
 	OperatorNamespace    string `koanf:"operator-namespace"`
+	// WatchNamespace is the Namespace the operator should be watching for changes.
+	// An empty value means the operator is running with cluster scope.
+	WatchNamespace string `koanf:"watch-namespace"`
 }
 
 var (

--- a/main.go
+++ b/main.go
@@ -63,6 +63,7 @@ func main() {
 		Port:               9443,
 		LeaderElection:     cfg.Config.EnableLeaderElection,
 		LeaderElectionID:   "d2ab61da.syn.tools",
+		Namespace:          cfg.Config.WatchNamespace,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start K8up operator")


### PR DESCRIPTION
## Summary

* Adds the possibility to watch only a single namespace

## Open issues

- [ ] The effectiveSchedule gets generated twice for the same job
- [ ] EffectiveSchedule is not being cleaned up after removing the schedule

## Logs

```
make e2e-test
kubectl create ns my-namespace
kubectl -n k8up-system set env deploy/k8up-operator BACKUP_WATCH_NAMESPACE="my-namespace"
```

```
$ kubectl -n my-namespace apply -f config/samples/k8up_v1alpha1_schedule.yaml
$ kubectl -n k8up-system get effectiveschedule
NAME                     SCHEDULE NAMESPACE   SCHEDULE NAME   GENERATED SCHEDULE   JOB TYPE   AGE
check-26bf9v5b4n7xjxdb   my-namespace         schedule-test   7 * * * *            check      22s
check-6q2dsbdwr49kgxmz   my-namespace         schedule-test   7 * * * *            check      22s

$ kubectl -n my-namespace delete schedule schedule-test
schedule.backup.appuio.ch "schedule-test" deleted

$ kubectl -n my-namespace get schedule              
No resources found in my-namespace namespace.

$ kubectl -n k8up-system get effectiveschedule         
NAME                     SCHEDULE NAMESPACE   SCHEDULE NAME   GENERATED SCHEDULE   JOB TYPE   AGE
check-26bf9v5b4n7xjxdb   my-namespace         schedule-test   7 * * * *            check      79s
check-6q2dsbdwr49kgxmz   my-namespace         schedule-test   7 * * * *            check      79s
```
```console
$ kubectl -n k8up-system logs deploy/k8up-operator
2021-04-28T11:45:41.756Z	DEBUG	controllers.Schedule	Randomized schedule	{"schedule": "my-namespace/schedule-test", "seed": "my-namespace/schedule-test@check", "from_schedule": "@hourly-random", "effective_schedule": "7 * * * *"}
2021-04-28T11:45:41.756Z	INFO	controllers.Schedule	registering schedule for	{"schedule": "my-namespace/schedule-test", "type": "prune", "cron": "*/2 * * * *"}
2021-04-28T11:45:41.756Z	INFO	controllers.Schedule	registering schedule for	{"schedule": "my-namespace/schedule-test", "type": "backup", "cron": "* * * * *"}
2021-04-28T11:45:41.756Z	INFO	controllers.Schedule	registering schedule for	{"schedule": "my-namespace/schedule-test", "type": "check", "cron": "7 * * * *"}
2021-04-28T11:45:41.756Z	INFO	controllers.Schedule	registering schedule for	{"schedule": "my-namespace/schedule-test", "type": "archive", "cron": "0 * * * *"}
2021-04-28T11:45:41.769Z	INFO	controllers.Schedule	created resource	{"schedule": "my-namespace/schedule-test", "name": {"namespace": "k8up-system", "name": "check-26bf9v5b4n7xjxdb"}}
2021-04-28T11:45:41.784Z	DEBUG	controllers.Schedule	Randomized schedule	{"schedule": "my-namespace/schedule-test", "seed": "my-namespace/schedule-test@check", "from_schedule": "@hourly-random", "effective_schedule": "7 * * * *"}
2021-04-28T11:45:41.784Z	INFO	controllers.Schedule	registering schedule for	{"schedule": "my-namespace/schedule-test", "type": "prune", "cron": "*/2 * * * *"}
2021-04-28T11:45:41.784Z	INFO	controllers.Schedule	registering schedule for	{"schedule": "my-namespace/schedule-test", "type": "backup", "cron": "* * * * *"}
2021-04-28T11:45:41.784Z	INFO	controllers.Schedule	registering schedule for	{"schedule": "my-namespace/schedule-test", "type": "check", "cron": "7 * * * *"}
2021-04-28T11:45:41.784Z	INFO	controllers.Schedule	registering schedule for	{"schedule": "my-namespace/schedule-test", "type": "archive", "cron": "0 * * * *"}
2021-04-28T11:45:41.789Z	INFO	controllers.Schedule	created resource	{"schedule": "my-namespace/schedule-test", "name": {"namespace": "k8up-system", "name": "check-6q2dsbdwr49kgxmz"}}
```

Without the namespace limit, K8up does not generate the ES twice and cleans it up as usual.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [ ] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [ ] Update the documentation.
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
