### PR TITLE
New configuration variable to pass options to restic

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -14,6 +14,7 @@ const (
 
 	ResticRepositoryEnvName = "RESTIC_REPOSITORY"
 	ResticPasswordEnvName   = "RESTIC_PASSWORD"
+	ResticOptionsEnvName    = "RESTIC_OPTIONS"
 
 	AwsAccessKeyIDEnvName     = "AWS_ACCESS_KEY_ID"
 	AwsSecretAccessKeyEnvName = "AWS_SECRET_ACCESS_KEY"
@@ -70,6 +71,10 @@ type Configuration struct {
 	EnableLeaderElection bool   `koanf:"enable-leader-election"`
 	LogLevel             string `koanf:"log-level"`
 	OperatorNamespace    string `koanf:"operator-namespace"`
+
+	// Allows to pass options to restic, see https://restic.readthedocs.io/en/stable/manual_rest.html?highlight=--option#usage-help
+	// Format: `key=value,key2=value2`
+	ResticOptions string `koanf:"restic-options"`
 }
 
 var (

--- a/docs/modules/ROOT/pages/references/config-reference.adoc
+++ b/docs/modules/ROOT/pages/references/config-reference.adoc
@@ -7,6 +7,8 @@ The Operator can be configured in two ways:
 
 == Environment Variables
 
+You need to define `BACKUP_OPERATOR_NAMESPACE`, but everything else can be left to their default values.
+
 `BACKUP_ANNOTATION`:: the annotation to be used for filtering, by default: `k8up.syn.tools/backup`
 `BACKUP_BACKUPCOMMANDANNOTATION`:: set the annotation name that identify the backup commands on Pods, by default: `k8up.syn.tools/backupcommand`
 `BACKUP_CHECKSCHEDULE`:: the default check schedule, by default: `0 0 * * 0`
@@ -37,15 +39,14 @@ The Operator can be configured in two ways:
 `BACKUP_JOBNAME`:: names for the backup job objects in OpenShift, default: `backupjob`
 `BACKUP_LOG_LEVEL`:: Set to "debug" to enable verbose logging, default: `info`
 `BACKUP_METRICS_BINDADDRESS`:: set the bind address for the prometheus endpoint, default: `:8080`
-`BACKUP_OPERATOR_NAMESPACE`:: set the namespace in which the K8up operator itself runs, Required.
+`BACKUP_OPERATOR_NAMESPACE`:: set the namespace in which the K8up operator itself runs, *required!*
 `BACKUP_PODEXECACCOUNTNAME`:: set the service account name that should be used for the pod command execution, default: `pod-executor`
 `BACKUP_PODEXECROLENAME`:: set the role name that should be used for pod command execution, default `pod-executor`
 `BACKUP_PODFILTER`:: the filter used to find the backup pods, default: `backupPod=true`
 `BACKUP_PODNAME`:: names for the backup pod objects in OpenShift, default: `backupjob-pod`
 `BACKUP_PROMURL`:: set the operator wide default prometheus push gateway, default `\http://127.0.0.1/`
 `BACKUP_RESTARTPOLICY`:: set the RestartPolicy for the backup jobs. According to the https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/[docs] this should be `OnFailure` for jobs that terminate, default: `OnFailure`
-
-You only need to adjust `BACKUP_IMAGE`, everything else can be left default.
+`BACKUP_RESTIC_OPTIONS`:: pass https://restic.readthedocs.io/en/stable/manual_rest.html?highlight=--option#usage-help[custom options to restic]
 
 == Global Settings
 

--- a/executor/generic.go
+++ b/executor/generic.go
@@ -204,6 +204,10 @@ func DefaultEnv(namespace string) EnvVarConverter {
 	defaults.SetString(cfg.AwsSecretAccessKeyEnvName, cfg.Config.GlobalSecretAccessKey)
 	defaults.SetString("HOSTNAME", namespace)
 
+	if cfg.Config.ResticOptions != "" {
+		defaults.SetString(cfg.ResticOptionsEnvName, cfg.Config.ResticOptions)
+	}
+
 	return defaults
 }
 


### PR DESCRIPTION
## Summary

On a global level, this PR allows to pass options down to restic.

Closes https://github.com/vshn/k8up/issues/424

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.
- [ ] Update tests.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
