### PR TITLE
Add a note about docs version bump on release

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,6 +1,6 @@
 name: k8up
 title: K8up Documentation
-version: 1.0.0
+version: 1.1.0
 prerelease: -master
 display_version: master
 start_page: ROOT:index.adoc

--- a/docs/modules/ROOT/pages/explanations/release.adoc
+++ b/docs/modules/ROOT/pages/explanations/release.adoc
@@ -1,4 +1,6 @@
-= Releasing k8up
+= Releasing K8up
+
+IMPORTANT: Before pushing a new Git tag, please adjust the version number in https://github.com/vshn/k8up/blob/master/docs/antora.yml[antora.yml].
 
 The release process is automated all the way through.
 It starts when a maintainer pushes a new git tag.

--- a/docs/modules/ROOT/partials/nav-explanation.adoc
+++ b/docs/modules/ROOT/partials/nav-explanation.adoc
@@ -1,6 +1,6 @@
 * xref:k8up:ROOT:explanations/architecture.adoc[Architecture]
 * xref:k8up:ROOT:explanations/ide.adoc[IDE Integration]
-* xref:k8up:ROOT:explanations/release.adoc[Releasing k8up]
+* xref:k8up:ROOT:explanations/release.adoc[Releasing K8up]
 * xref:k8up:ROOT:explanations/missing-docs.adoc[Missing Documentation]
 * xref:k8up:ROOT:explanations/supported-k8s-versions.adoc[Supported Kubernetes Versions]
 * xref:k8up:ROOT:explanations/what-has-changed-in-v1.adoc[What has changed in K8up v1.0]


### PR DESCRIPTION
## Summary

As not bumping the version number in antora.yml causes all sorts of issues with Antora and as this process isn't automated yet, this hint should help to not forget it. At least not every time...

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.