### PR TITLE
Remove duplicate keys initialDelaySeconds, timeoutSeconds

### DIFF
--- a/docs/modules/ROOT/examples/tutorial/mariadb/deployment.yaml
+++ b/docs/modules/ROOT/examples/tutorial/mariadb/deployment.yaml
@@ -31,8 +31,6 @@ spec:
             - "-i"
             - "-c"
             - mysql -h 127.0.0.1 -uroot -p"${MARIADB_ROOT_PASSWORD}" -D mysql -e 'SELECT 1'
-          initialDelaySeconds: 5
-          timeoutSeconds: 1
         livenessProbe:
           timeoutSeconds: 1
           initialDelaySeconds: 30


### PR DESCRIPTION
## Summary

This PR removes two duplicate keys from the MariaDB tutorial deployment's `spec.template.spec.readinessProbe` section. This way, the k8up tutorial works again as documented.

Otherwise kubectl throws an error:

```
error: map[string]interface {}(nil): yaml: unmarshal errors:
  line 37: mapping key "timeoutSeconds" already defined at line 27
  line 36: mapping key "initialDelaySeconds" already defined at line 28
```

At least when using kubectl 1.21.1 against apiserver 1.20.2. I'm not sure which part (kubectl or the API server) does these validations.

## Checklist


- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
