### PR TITLE
Add job history defaults to documentation

### DIFF
--- a/docs/modules/ROOT/pages/references/config-reference.adoc
+++ b/docs/modules/ROOT/pages/references/config-reference.adoc
@@ -24,8 +24,8 @@ You need to define `BACKUP_OPERATOR_NAMESPACE`, but everything else can be left 
 `BACKUP_GLOBAL_CPU_LIMIT`:: set the CPU limit for scheduled jobs
 `BACKUP_GLOBAL_CPU_REQUEST`:: set the CPU request for scheduled jobs
 `BACKUP_GLOBALKEEPJOBS`:: set the number of old jobs to keep when cleaning up, applies to all job types
-`BACKUP_GLOBAL_FAILED_JOBS_HISTORY_LIMIT`:: set the number of old, failed jobs to keep when cleaning up, applies to all job types
-`BACKUP_GLOBAL_SUCCESSFUL_JOBS_HISTORY_LIMIT`:: set the number of old, successful jobs to keep when cleaning up, applies to all job types
+`BACKUP_GLOBAL_FAILED_JOBS_HISTORY_LIMIT`:: set the number of old, failed jobs to keep when cleaning up, applies to all job types, default: `3`
+`BACKUP_GLOBAL_SUCCESSFUL_JOBS_HISTORY_LIMIT`:: set the number of old, successful jobs to keep when cleaning up, applies to all job types, default: `3`
 `BACKUP_GLOBAL_MEMORY_LIMIT`:: set the memory limit for scheduled jobs
 `BACKUP_GLOBAL_MEMORY_REQUEST`:: set the memory request for scheduled jobs
 `BACKUP_GLOBALREPOPASSWORD`:: set the restic repository password to be used globally


### PR DESCRIPTION
## Summary

Adds the defaults for `BACKUP_GLOBAL_FAILED_JOBS_HISTORY_LIMIT` and `BACKUP_GLOBAL_SUCCESSFUL_JOBS_HISTORY_LIMIT` to the documentation.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
