### PR TITLE
Unified Logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ include Makefile.vars.mk
 include Makefile.restic-integration.mk
 
 e2e_make := $(MAKE) -C e2e
-go_build ?= go build -o $(BIN_FILENAME) cmd/k8up/main.go
+go_build ?= go build -o $(BIN_FILENAME) $(K8UP_MAIN_GO)
 
 all: build ## Invokes the build target
 
@@ -55,15 +55,15 @@ run: export BACKUP_ENABLE_LEADER_ELECTION = $(ENABLE_LEADER_ELECTION)
 run: export K8UP_DEBUG = true
 run: export BACKUP_OPERATOR_NAMESPACE = default
 run: fmt vet ## Run against the configured Kubernetes cluster in ~/.kube/config. Use ARGS to pass arguments to the command, e.g. `make run ARGS="--help"`
-	go run ./cmd/k8up/main.go $(CMD) $(ARGS)
+	go run $(K8UP_MAIN_GO) $(ARGS) $(CMD) $(CMD_ARGS)
 
 .PHONY: run-operator
 run-operator: CMD := operator
-run-operator: run  ## Run the operator module against the configured Kubernetes cluster in ~/.kube/config. Use ARGS to pass arguments to the command, e.g. `make run ARGS="--help"`
+run-operator: run  ## Run the operator module against the configured Kubernetes cluster in ~/.kube/config. Use ARGS to pass arguments to the command, e.g. `make run-operator ARGS="--debug" CMD_ARGS="--help"`
 
 .PHONY: run-restic
 run-restic: CMD := restic
-run-restic: run  ## Run the restic module. Use ARGS to pass arguments to the command, e.g. `make run ARGS="--help"`
+run-restic: run  ## Run the restic module. Use ARGS to pass arguments to the command, e.g. `make run-restic ARGS="--debug" CMD_ARGS="--check"`
 
 .PHONY: install
 install: generate ## Install CRDs into a cluster

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -1,5 +1,7 @@
 IMG_TAG ?= latest
 
+K8UP_MAIN_GO ?= cmd/k8up/main.go
+
 CURDIR ?= $(shell pwd)
 BIN_FILENAME ?= $(CURDIR)/$(PROJECT_ROOT_DIR)/k8up
 

--- a/cmd/logger.go
+++ b/cmd/logger.go
@@ -3,18 +3,18 @@ package cmd
 import (
 	"github.com/go-logr/logr"
 	"github.com/urfave/cli/v2"
-	"go.uber.org/zap/zapcore"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-func Logger(c *cli.Context, name string) logr.Logger {
-	level := zapcore.InfoLevel
-	if c.Bool("debug") {
-		level = zapcore.DebugLevel
-	}
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.Level(level)))
-	setupLog := ctrl.Log.WithName(name)
+const loggerMetadataKeyName = "logger"
 
-	return setupLog
+// AppLogger retrieves the application-wide logger instance from the cli.Context's Metadata.
+// This function will return nil if SetAppLogger was not called before this function is called.
+func AppLogger(c *cli.Context) logr.Logger {
+	return c.App.Metadata[loggerMetadataKeyName].(logr.Logger)
+}
+
+// SetAppLogger stores the application-wide logger instance to the cli.Context's Metadata,
+// so that it can later be retrieved by AppLogger.
+func SetAppLogger(c *cli.Context, logger logr.Logger) {
+	c.App.Metadata[loggerMetadataKeyName] = logger
 }

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -35,8 +35,9 @@ var (
 )
 
 func operatorMain(c *cli.Context) error {
-	operatorLog := cmd.Logger(c, "operator")
+	operatorLog := cmd.AppLogger(c).WithName("operator")
 	operatorLog.Info("initializing")
+	ctrl.SetLogger(operatorLog)
 
 	executor.GetExecutor()
 
@@ -66,7 +67,7 @@ func operatorMain(c *cli.Context) error {
 		"Prune":    &controllers.PruneReconciler{},
 		"Job":      &controllers.JobReconciler{},
 	} {
-		if err := reconciler.SetupWithManager(mgr, ctrl.Log.WithName("controllers").WithName(name)); err != nil {
+		if err := reconciler.SetupWithManager(mgr, operatorLog.WithName("controllers").WithName(name)); err != nil {
 			operatorLog.Error(err, "unable to initialize operator mode", "step", "controller", "controller", name)
 			return fmt.Errorf("unable to setup reconciler: %w", err)
 		}

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -58,7 +58,7 @@ var (
 )
 
 func resticMain(c *cli.Context) error {
-	resticLog := cmd.Logger(c, "wrestic")
+	resticLog := cmd.AppLogger(c).WithName("wrestic")
 	resticLog.Info("initializing")
 
 	tags = c.StringSlice("tag")
@@ -68,7 +68,7 @@ func resticMain(c *cli.Context) error {
 
 	statHandler := stats.NewHandler(os.Getenv(promURLEnv), os.Getenv(resticCli.Hostname), os.Getenv(webhookURLEnv), resticLog)
 
-	resticCLI := resticCli.New(ctx, resticLog, statHandler)
+	resticCLI := resticCli.New(ctx, resticLog.WithName("restic"), statHandler)
 
 	return run(c.Context, resticCLI, resticLog)
 }


### PR DESCRIPTION
## Summary

All loggers should be derived from the `cmd.AppLogger()`, which is created after the flags are parsed (to determine whether to enable debug output or not) but before the first actual action/sub-command is invoked by [the CLI library](https://github.com/urfave/cli).

Closes #478 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [ ] Update the documentation.
- [ ] Update tests.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
