### PR TITLE
set version to master for Antora

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,6 +1,6 @@
 name: k8up
 title: K8up Documentation
-version: 1.2.0
+version: master
 prerelease: -master
 display_version: master
 start_page: ROOT:index.adoc


### PR DESCRIPTION
The master branch should set the Antora documentation version to master.

## Summary

For correct documentation versioning the master branch should set the version of the documentation to master.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog